### PR TITLE
Issue with calling nested given actions multiple times?

### DIFF
--- a/SpecEasy.Specs/GivenCount/GivenCountSpecs.cs
+++ b/SpecEasy.Specs/GivenCount/GivenCountSpecs.cs
@@ -1,0 +1,27 @@
+﻿using System.Collections.Generic;
+using NUnit.Framework;
+using SpecEasy.Specs.SetUpAndTearDownSpecs;
+
+namespace SpecEasy.Specs.GivenCount
+{
+    public class GivenCountSpecs : Spec<FakeClass>
+    {
+        public void GivensAreCalledOncePerThenInTheProperOrderSpec()
+        {
+            var givenCalls = new Stack<int>();
+
+            When("running a test that has nested givens preceding a then", () => SUT.DoNothing());
+
+            Given("a given is called at nesting level 0.", () => givenCalls.Push(0)).Verify(() =>
+                Given("a given is called at nesting level 1", () => givenCalls.Push(1)).Verify(() =>
+                    Given("a given is called at nesting level 2", () => givenCalls.Push(2)).Verify(() =>
+                            Then("each given should have been called only once and in the proper order", () =>
+                                {
+                                    Assert.That(givenCalls.Count, Is.EqualTo(3));
+                                    Assert.That(givenCalls.Pop(), Is.EqualTo(2));
+                                    Assert.That(givenCalls.Pop(), Is.EqualTo(1));
+                                    Assert.That(givenCalls.Pop(), Is.EqualTo(0));
+                                }))));
+        }
+    }
+}

--- a/SpecEasy.Specs/SpecEasy.Specs.csproj
+++ b/SpecEasy.Specs/SpecEasy.Specs.csproj
@@ -65,6 +65,7 @@
     <Compile Include="BeforeEachAndAfterEachExampleSpecs\BeforeEachExampleCalledCorrectNumberOfTimesSpec.cs" />
     <Compile Include="BeforeEachAndAfterEachExampleSpecs\BeforeEachExampleGetsCalledSpec.cs" />
     <Compile Include="FizzBuzz\FizzBuzzSpecs.cs" />
+    <Compile Include="GivenCount\GivenCountSpecs.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/SpecEasy/Context.cs
+++ b/SpecEasy/Context.cs
@@ -7,7 +7,6 @@ namespace SpecEasy
 
     internal class Context : IContext
     {
-        private bool setupActionRun = false;
         private readonly Action setupAction = delegate { };
         private Action enterAction = delegate { };
 
@@ -39,10 +38,7 @@ namespace SpecEasy
 
         public void SetupContext()
         {
-            if (setupActionRun) return;
-
             setupAction();
-            setupActionRun = true;
         }
     }
 }

--- a/SpecEasy/Context.cs
+++ b/SpecEasy/Context.cs
@@ -7,6 +7,7 @@ namespace SpecEasy
 
     internal class Context : IContext
     {
+        private bool setupActionRun = false;
         private readonly Action setupAction = delegate { };
         private Action enterAction = delegate { };
 
@@ -38,7 +39,10 @@ namespace SpecEasy
 
         public void SetupContext()
         {
+            if (setupActionRun) return;
+
             setupAction();
+            setupActionRun = true;
         }
     }
 }

--- a/SpecEasy/Spec.cs
+++ b/SpecEasy/Spec.cs
@@ -114,7 +114,6 @@ namespace SpecEasy
                 contexts = new Dictionary<string, Context>();
                 when = cachedWhen;
 
-                InitializeContext(contextList);
                 givenContext.EnterContext();
 
                 if (depth > 0)


### PR DESCRIPTION
Noticed this (potential) issue when writing specs where the action invoked in Given calls was not idempotent (creating records in a database). Three levels of nested Given calls leading up to a Then resulted in the actions defined by the givens being called multiple times

For example, consider a test laid out like this:

When(something)
Given(given 1 action).Verify
  Given(given 2 action).Verify
    Given(given 3 action).Verify
      Then(verify some expected state)

Given 1 action
Given 1 action (again) -> Given 2 action
Given 1 action (againt) -> Given 2 action (again) -> Given 3 action -> When -> Then

Should this be happening this way? I was under the impression that the setup actions defined by the givens wouldn't actually be invoked until a 'Then' was encountered. The pull request contains a failing test that illustrates what I mean.
