### PR TITLE
Fix for issue with nested givens having their setup actions called multiple times

### DIFF
--- a/SpecEasy.Specs/GivenCount/GivenCountSpecs.cs
+++ b/SpecEasy.Specs/GivenCount/GivenCountSpecs.cs
@@ -6,22 +6,59 @@ namespace SpecEasy.Specs.GivenCount
 {
     public class GivenCountSpecs : Spec<FakeClass>
     {
-        public void GivensAreCalledOncePerThenInTheProperOrderSpec()
-        {
-            var givenCalls = new Stack<int>();
+        private List<string> _givenCalls;
 
+        public void GivensAreCalledOncePerThenInTheProperOrderWithSimpleNestingSpec()
+        {
+            _givenCalls = new List<string>();
             When("running a test that has nested givens preceding a then", () => SUT.DoNothing());
 
-            Given("a given is called at nesting level 0.", () => givenCalls.Push(0)).Verify(() =>
-                Given("a given is called at nesting level 1", () => givenCalls.Push(1)).Verify(() =>
-                    Given("a given is called at nesting level 2", () => givenCalls.Push(2)).Verify(() =>
-                            Then("each given should have been called only once and in the proper order", () =>
-                                {
-                                    Assert.That(givenCalls.Count, Is.EqualTo(3));
-                                    Assert.That(givenCalls.Pop(), Is.EqualTo(2));
-                                    Assert.That(givenCalls.Pop(), Is.EqualTo(1));
-                                    Assert.That(givenCalls.Pop(), Is.EqualTo(0));
-                                }))));
+            Given("a given is called at nesting level 0.", () => _givenCalls.Add("0")).Verify(() =>
+                Given("a given is called at nesting level 1", () => _givenCalls.Add("1")).Verify(() =>
+                    Given("a given is called at nesting level 2", () => _givenCalls.Add("2")).Verify(() =>
+                            Then("each given should have been called only once and in the proper order", () => 
+                                VerifyGivenCalls("0 -> 1 -> 2", clearValuesAfterVerify: false)).
+                           Then("each given is called a second time for the second then", () => 
+                               VerifyGivenCalls("0 -> 1 -> 2 -> 0 -> 1 -> 2", clearValuesAfterVerify: false)))));
+        }
+
+        public void GivensAreCalledOncePerThenInTheProperOrderWithMixedNestingSpec()
+        {
+            _givenCalls = new List<string>();
+
+            When("running a test that has nested givens at varying levels with then calls intertwined.", () => SUT.DoNothing());
+
+            Given("a top level given is used to establish 'global' context for the spec", () => _givenCalls.Add("0")).Verify(() =>
+                {
+                    Given("a nested given is used at level 1.1", () => _givenCalls.Add("1.1")).Verify(() =>
+                        Given("a nested given is used at level 2.1", () => _givenCalls.Add("2.1")).Verify(() =>
+                        Then("each given should be called once leading up to this then", () =>
+                            VerifyGivenCalls("0 -> 1.1 -> 2.1"))));
+
+                    Given("a nested given is used at level 1.2", () => _givenCalls.Add("1.2")).Verify(() =>
+                        {
+                            Given("a nested given is used at level 2.2", () => _givenCalls.Add("2.2")).Verify(() =>
+                                Then("each given leading up to this then should be called once.", () =>
+                                    VerifyGivenCalls("0 -> 1.2 -> 2.2")));
+
+                            Given("a nested given is used at level 2.3", () => _givenCalls.Add("2.3")).Verify(() =>
+                                Given("a nested given is used at level 3.1", () => _givenCalls.Add("3.1")).Verify(() =>
+                                    {
+                                        Then("all givens leading up to this then should be called once in the proper order.", () =>
+                                            VerifyGivenCalls("0 -> 1.2 -> 2.3 -> 3.1", clearValuesAfterVerify: true));
+
+                                        Then("a second then immediately following the first should repeat the same givens in the same order.", () =>
+                                            VerifyGivenCalls("0 -> 1.2 -> 2.3 -> 3.1"));
+                                    }));
+                        });
+                });
+        }
+
+        private void VerifyGivenCalls(string expectedValue, bool clearValuesAfterVerify = true)
+        {
+            var givenCallListString = string.Join(" -> ", _givenCalls);
+            Assert.That(givenCallListString, Is.EqualTo(expectedValue));
+            if (clearValuesAfterVerify) _givenCalls.Clear();
         }
     }
 }

--- a/SpecEasy.Specs/GivenCount/GivenCountSpecs.cs
+++ b/SpecEasy.Specs/GivenCount/GivenCountSpecs.cs
@@ -1,0 +1,27 @@
+﻿using System.Collections.Generic;
+using NUnit.Framework;
+using SpecEasy.Specs.SetUpAndTearDownSpecs;
+
+namespace SpecEasy.Specs.GivenCount
+{
+    public class GivenCountSpecs : Spec<FakeClass>
+    {
+        public void GivensAreCalledOncePerThenInTheProperOrderSpec()
+        {
+            var givenCalls = new Stack<int>();
+
+            When("running a test that has nested givens preceding a then", () => SUT.DoNothing());
+
+            Given("a given is called at nesting level 0.", () => givenCalls.Push(0)).Verify(() =>
+                Given("a given is called at nesting level 1", () => givenCalls.Push(1)).Verify(() =>
+                    Given("a given is called at nesting level 2", () => givenCalls.Push(2)).Verify(() =>
+                            Then("each given should have been called only once and in the proper order", () =>
+                                {
+                                    Assert.That(givenCalls.Count, Is.EqualTo(3));
+                                    Assert.That(givenCalls.Pop(), Is.EqualTo(2));
+                                    Assert.That(givenCalls.Pop(), Is.EqualTo(1));
+                                    Assert.That(givenCalls.Pop(), Is.EqualTo(0));
+                                }))));
+        }
+    }
+}

--- a/SpecEasy.Specs/SpecEasy.Specs.csproj
+++ b/SpecEasy.Specs/SpecEasy.Specs.csproj
@@ -65,6 +65,7 @@
     <Compile Include="BeforeEachAndAfterEachExampleSpecs\BeforeEachExampleCalledCorrectNumberOfTimesSpec.cs" />
     <Compile Include="BeforeEachAndAfterEachExampleSpecs\BeforeEachExampleGetsCalledSpec.cs" />
     <Compile Include="FizzBuzz\FizzBuzzSpecs.cs" />
+    <Compile Include="GivenCount\GivenCountSpecs.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/SpecEasy/Context.cs
+++ b/SpecEasy/Context.cs
@@ -7,7 +7,6 @@ namespace SpecEasy
 
     internal class Context : IContext
     {
-        private bool setupActionRun = false;
         private readonly Action setupAction = delegate { };
         private Action enterAction = delegate { };
 
@@ -39,10 +38,7 @@ namespace SpecEasy
 
         public void SetupContext()
         {
-            if (setupActionRun) return;
-
             setupAction();
-            setupActionRun = true;
         }
     }
 }

--- a/SpecEasy/Context.cs
+++ b/SpecEasy/Context.cs
@@ -7,6 +7,7 @@ namespace SpecEasy
 
     internal class Context : IContext
     {
+        private bool setupActionRun = false;
         private readonly Action setupAction = delegate { };
         private Action enterAction = delegate { };
 
@@ -38,7 +39,10 @@ namespace SpecEasy
 
         public void SetupContext()
         {
+            if (setupActionRun) return;
+
             setupAction();
+            setupActionRun = true;
         }
     }
 }

--- a/SpecEasy/Spec.cs
+++ b/SpecEasy/Spec.cs
@@ -114,7 +114,6 @@ namespace SpecEasy
                 contexts = new Dictionary<string, Context>();
                 when = cachedWhen;
 
-                InitializeContext(contextList);
                 givenContext.EnterContext();
 
                 if (depth > 0)


### PR DESCRIPTION
A fix for this issue described in a previous pull request:

For example, consider a test laid out like this:

When(something)
Given(given 1 action).Verify
Given(given 2 action).Verify
Given(given 3 action).Verify
Then(verify some expected state)

Given 1 action
Given 1 action (again) -> Given 2 action
Given 1 action (againt) -> Given 2 action (again) -> Given 3 action -> When -> Then

The commits in this request have two possible ways to fix this:

1 - Add a flag to the 'context' class to figure out if the context setup action has already been invoked.
2 - Remove what appears to be an extraneous call to 'InitializeContext' from within the VerifyContexts method
