### PR TITLE
Fix issue #8 - move IoC setup to BeforeEachExample

### DIFF
--- a/SpecEasy.Specs/BeforeEachAndAfterEachExampleSpecs/GetSetInBeforeEachExampleSpec.cs
+++ b/SpecEasy.Specs/BeforeEachAndAfterEachExampleSpecs/GetSetInBeforeEachExampleSpec.cs
@@ -1,0 +1,82 @@
+﻿using NUnit.Framework;
+using Rhino.Mocks;
+
+namespace SpecEasy.Specs.BeforeEachAndAfterEachExampleSpecs
+{
+    public class GetSetInBeforeEachExampleSpec : Spec<GetSetInBeforeEachExampleSpec.ClassWithDependencies>
+    {
+        protected override void BeforeEachExample()
+        {
+            base.BeforeEachExample();
+            Get<IDependency>().Stub(dep => dep.GetValue()).Return(123);
+            Set<IAnotherDependency>(new AnotherDependency(789));
+        }
+
+        public void Run()
+        {
+            var result = 0;
+
+            When("using a dependency", () => result = SUT.UseDependency());
+            
+            Given("dependencies were set up in BeforeEachExample").Verify(() =>
+                Then("it should get a value from the first dependency that was set up", () => Assert.That(result, Is.EqualTo(123))).
+                Then("it should get a value from the second dependency that was set up", () => Assert.That(SUT.UseAnotherDependency(), Is.EqualTo(789))));
+
+            Given("dependency overriden in a Given", () =>
+            {
+                Get<IDependency>().Stub(dep => dep.GetValue()).Return(456).Repeat.Any(); // Repeat.Any replaces the previous Stub
+                Set<IAnotherDependency>(new AnotherDependency(987));
+            }).Verify(() =>
+                Then("it should get the new value from the first dependency", () => Assert.That(result, Is.EqualTo(456))).
+                Then("it should get the new value from the second dependency", () => Assert.That(SUT.UseAnotherDependency(), Is.EqualTo(987))));
+        }
+
+        public class ClassWithDependencies
+        {
+            private readonly IDependency dependency;
+            private readonly IAnotherDependency anotherDependency;
+
+            public ClassWithDependencies(IDependency dependency, IAnotherDependency anotherDependency)
+            {
+                this.dependency = dependency;
+                this.anotherDependency = anotherDependency;
+            }
+
+            public int UseDependency()
+            {
+                var value = dependency.GetValue();
+                return value;
+            }
+
+            public int UseAnotherDependency()
+            {
+                return anotherDependency.GetAnotherValue();
+            }
+        }
+
+        public interface IDependency
+        {
+            int GetValue();
+        }
+
+        public interface IAnotherDependency
+        {
+            int GetAnotherValue();
+        }
+
+        public class AnotherDependency : IAnotherDependency
+        {
+            private readonly int value;
+
+            public AnotherDependency(int value)
+            {
+                this.value = value;
+            }
+
+            public int GetAnotherValue()
+            {
+                return value;
+            }
+        }
+    }
+}

--- a/SpecEasy.Specs/BeforeEachAndAfterEachExampleSpecs/SutInBeforeEachExampleSpec.cs
+++ b/SpecEasy.Specs/BeforeEachAndAfterEachExampleSpecs/SutInBeforeEachExampleSpec.cs
@@ -1,0 +1,32 @@
+﻿using NUnit.Framework;
+
+namespace SpecEasy.Specs.BeforeEachAndAfterEachExampleSpecs
+{
+    class SutInBeforeEachExampleSpec : Spec<SutInBeforeEachExampleSpec.SutWithValueTypeDependency>
+    {
+        protected override void BeforeEachExample()
+        {
+            base.BeforeEachExample();
+            SUT = new SutWithValueTypeDependency(123);
+        }
+
+        public void Run()
+        {
+            var value = 0;
+
+            When("getting value from SUT", () => value = SUT.Value);
+            Given("SUT was set up in BeforeEachExample").Verify(() =>
+                Then("it should get the value from the SUT set up in BeforeEachExample", () => Assert.That(value, Is.EqualTo(123))));
+        }
+
+        public class SutWithValueTypeDependency
+        {
+            public int Value { get; private set; }
+
+            public SutWithValueTypeDependency(int value)
+            {
+                Value = value;
+            }
+        }
+    }
+}

--- a/SpecEasy.Specs/SpecEasy.Specs.csproj
+++ b/SpecEasy.Specs/SpecEasy.Specs.csproj
@@ -77,6 +77,8 @@
     <Compile Include="BeforeEachAndAfterEachExampleSpecs\AfterEachExampleGetsCalledSpec.cs" />
     <Compile Include="BeforeEachAndAfterEachExampleSpecs\BeforeEachExampleCalledCorrectNumberOfTimesSpec.cs" />
     <Compile Include="BeforeEachAndAfterEachExampleSpecs\BeforeEachExampleGetsCalledSpec.cs" />
+    <Compile Include="BeforeEachAndAfterEachExampleSpecs\GetSetInBeforeEachExampleSpec.cs" />
+    <Compile Include="BeforeEachAndAfterEachExampleSpecs\SutInBeforeEachExampleSpec.cs" />
     <Compile Include="DatabaseIntegration\DatabaseIntegrationSetup.cs" />
     <Compile Include="FizzBuzz\FizzBuzzSpecs.cs" />
     <Compile Include="GenericSpec\AutoMockSpec.cs" />

--- a/SpecEasy/GenericSpec.cs
+++ b/SpecEasy/GenericSpec.cs
@@ -14,8 +14,16 @@ namespace SpecEasy
             return MockRepository.GenerateMock<T>();
         }
 
+        private void RequireMockingContainer()
+        {
+            if (MockingContainer == null)
+                throw new InvalidOperationException(
+                    "This method cannot be called before the test context is initialized.");
+        }
+
         protected T Get<T>()
         {
+            RequireMockingContainer();
             return (T)MockingContainer.Resolve(typeof(T), new ResolveOptions
             {
                 UnregisteredResolutionRegistrationOption = UnregisteredResolutionRegistrationOptions.RegisterAsSingleton,
@@ -32,6 +40,7 @@ namespace SpecEasy
 
         protected void Set<T>(T item)
         {
+            RequireMockingContainer();
             MockingContainer.Register(typeof(T), item);
         }
 
@@ -65,9 +74,9 @@ namespace SpecEasy
             mock.AssertWasNotCalled(action, methodOptions);
         }
 
-        protected override void InitializeTest()
+        protected override void BeforeEachExample()
         {
-            base.InitializeTest();
+            base.BeforeEachExample();
             MockingContainer = new TinyIoCContainer();
             MockingContainer.Register(typeof(TUnit)).AsSingleton();
         }

--- a/SpecEasy/Spec.cs
+++ b/SpecEasy/Spec.cs
@@ -118,6 +118,7 @@ namespace SpecEasy
 
                 if (depth > 0)
                     contextList.Add(namedContext);
+
                 VerifySpecs(contextList);
                 VerifyContexts(contextList, depth + 1);
                 if (contextList.Any())
@@ -148,6 +149,7 @@ namespace SpecEasy
             foreach (var spec in then)
             {
                 Before();
+
                 output.AppendLine(thenText + spec.Key);
                 if (thenText == "then ")
                     thenText = Indent("and ", 1);
@@ -227,16 +229,11 @@ namespace SpecEasy
 
         private void InitializeContext(IEnumerable<KeyValuePair<string, Context>> contextList)
         {
-            InitializeTest();
             foreach (var action in contextList.Select(kvp => kvp.Value))
             {
                 Before();
                 action.SetupContext();
             }
-        }
-
-        protected virtual void InitializeTest()
-        {
         }
 
         private static string Indent(string text, int depth)


### PR DESCRIPTION
Fix for issue #8.

The problem was that `InitializeTest`, where the generic Spec class sets up its DI container, was not being called until after `BeforeEachExample`. Moving the setup code out of InitializeTest and into a BeforeEachExample override fixed the problem.

I decided to remove `InitializeTest` entirely. It seems to be redundant now that we have `BeforeEachExample`. This is technically a breaking change.
