### PR TITLE
Added IgnoreSpec attribute for test methods

### DIFF
--- a/SpecEasy.Specs/GenericSpec/TestSkippingSpec.cs
+++ b/SpecEasy.Specs/GenericSpec/TestSkippingSpec.cs
@@ -1,0 +1,46 @@
+﻿using System.Diagnostics;
+using System.IO;
+using System.Text;
+using NUnit.Framework;
+
+namespace SpecEasy.Specs.GenericSpec
+{
+    public class TestSkippingSpec : Spec<TestSkippingSpec.IgnoreTestClass>
+    {
+        private readonly MemoryStream stream = new MemoryStream();
+        private const string IgnoreSpectOutput = "inside a test method ignored by the IgnoreSpec attribute";
+
+        public void IgnoreSpecAttribute()
+        {
+            When("running all tests in a class", () => SUT.Verify());
+
+            Given("a test method that is marked ignored with the IgnoreSpec attribute").Verify(() =>
+                Then("it should not run the test", () => OutputShouldNotContain(IgnoreSpectOutput)));
+        }
+
+        protected override void BeforeEachExample()
+        {
+            base.BeforeEachExample();
+
+            var listener = new TextWriterTraceListener(stream);
+            Debug.Listeners.Add(listener);
+            Debug.AutoFlush = true;
+        }
+
+        private void OutputShouldNotContain(string outputText)
+        {
+            var output = Encoding.ASCII.GetString(stream.ToArray());
+            Assert.That(output, Is.Not.StringContaining(outputText));
+        }
+
+        public class IgnoreTestClass : Spec
+        {
+            [IgnoreSpec]
+            public virtual void IgnoredTest()
+            {
+                When(IgnoreSpectOutput, () => { });
+                Then("this should not show up in the test output", () => { });
+            }
+        }
+    }
+}

--- a/SpecEasy.Specs/SpecEasy.Specs.csproj
+++ b/SpecEasy.Specs/SpecEasy.Specs.csproj
@@ -82,6 +82,7 @@
     <Compile Include="DatabaseIntegration\DatabaseIntegrationSetup.cs" />
     <Compile Include="FizzBuzz\FizzBuzzSpecs.cs" />
     <Compile Include="GenericSpec\AutoMockSpec.cs" />
+    <Compile Include="GenericSpec\TestSkippingSpec.cs" />
     <Compile Include="GivenCount\GivenCountSpecs.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>

--- a/SpecEasy/IgnoreSpecAttribute.cs
+++ b/SpecEasy/IgnoreSpecAttribute.cs
@@ -1,0 +1,9 @@
+﻿using System;
+
+namespace SpecEasy
+{
+    [AttributeUsage(AttributeTargets.Method, AllowMultiple = false)]
+    public class IgnoreSpecAttribute : Attribute
+    {
+    }
+}

--- a/SpecEasy/Spec.cs
+++ b/SpecEasy/Spec.cs
@@ -89,7 +89,7 @@ namespace SpecEasy
         private void CreateMethodContexts()
         {
             var type = GetType();
-            var methods = type.GetMethods();
+            var methods = GetValidMethods(type);
             var baseMethods = type.BaseType != null ? type.BaseType.GetMethods() : new MethodInfo[] {};
             var declaredMethods = methods.Where(m => baseMethods.All(bm => bm.Name != m.Name));
             foreach (var m in declaredMethods)
@@ -97,6 +97,12 @@ namespace SpecEasy
                 var method = m;
                 Given(method.Name).Verify(() => method.Invoke(this, null));
             }
+        }
+
+        private static IEnumerable<MethodInfo> GetValidMethods(Type type)
+        {
+            var methods = type.GetMethods();
+            return methods.Where(m => !m.GetCustomAttributes(typeof (IgnoreSpecAttribute), false).Any());
         }
 
         private void VerifyContexts()

--- a/SpecEasy/SpecEasy.csproj
+++ b/SpecEasy/SpecEasy.csproj
@@ -71,6 +71,7 @@
   <ItemGroup>
     <Compile Include="Action.cs" />
     <Compile Include="Context.cs" />
+    <Compile Include="IgnoreSpecAttribute.cs" />
     <Compile Include="TinyIoC.cs" />
     <Compile Include="VerifyContext.cs" />
     <Compile Include="Spec.cs" />


### PR DESCRIPTION
Methods inside of a `Spec` class marked with `[IgnoreSpec]` will be skipped. Currently this means that nothing will be listed in the output. Comparing the behavior to [RSpec's Exclusion filters](https://www.relishapp.com/rspec/rspec-core/v/2-5/docs/filtering/exclusion-filters), I'm thinking this is the best way to handle it.

Added a test in `TestSkippingSpec` to verify the behavior. This is done by checking the debug output that the `Verify` call performs and making sure the test method's text is not in there.
