### PR TITLE
Break out each assertion into its own test

### DIFF
--- a/SpecEasy.Specs/BeforeEachAndAfterEachExampleSpecs/AfterEachExampleGetsCalledSpec.cs
+++ b/SpecEasy.Specs/BeforeEachAndAfterEachExampleSpecs/AfterEachExampleGetsCalledSpec.cs
@@ -4,40 +4,36 @@ namespace SpecEasy.Specs.SetUpAndTearDownSpecs
 {
     public class AfterEachExampleGetsCalledSpec : Spec<FakeClass>
     {
-        private int timesCalled = 0;
+        private int timesSet = 0;
 
         public void AfterEachExampleSpec()
         {
-            timesCalled = 0;
-
-            When("running a test in a class that overrides AfterEachExample", () => SUT.DoNothing());
-            Then("it should not AfterEachExample before the first Then", () => Assert.That(timesCalled, Is.EqualTo(0)));
-            Then("it should call AfterEachExample before the second Then", () => Assert.That(timesCalled, Is.EqualTo(1)));
+            When("running a test in a class that resets a variable in AfterEachExample", () => SUT.DoNothing());
+            Then("the variable should be reset before the first Then, which sets it", () => Assert.That(timesSet++ == 0));
+            Then("the variable should be reset before the second Then, which sets it", () => Assert.That(timesSet++ == 0));
         }
 
         public void AfterEachExampleWithGivenSpec()
         {
-            timesCalled = 0;
-
-            When("running a test in a class that overrides AfterEachExample", () => SUT.DoNothing());
+            When("running a test in a class that resets a variable in AfterEachExample", () => SUT.DoNothing());
 
             Given("there is a given", () => SUT.DoNothing()).Verify(() => {
-                Then("it should not call AfterEachExample before the first Then", () => Assert.That(timesCalled, Is.EqualTo(0)));
-                Then("it should call AfterEachExample before the second Then", () => Assert.That(timesCalled, Is.EqualTo(1)));
+                Then("the variable should be reset before the first Then, which sets it", () => Assert.That(timesSet++ == 0));
+                Then("the variable should be reset before the second Then, which sets it", () => Assert.That(timesSet++ == 0));
             });
 
             Given("there is another given", () => SUT.DoNothing()).Verify(() =>
                 {
-                    Then("it should call AfterEachExample again before the third Then", () => Assert.That(timesCalled, Is.EqualTo(2)));
-                    Given("we have nested givens", () => SUT.DoNothing()).Verify(() => 
-                        Then("it should call AfterEachExample again before the nested Then", () => Assert.That(timesCalled, Is.EqualTo(3))));
+                    Then("the variable should be reset before the third Then, which sets it", () => Assert.That(timesSet++ == 0));
+                    Given("we have nested givens", () => SUT.DoNothing()).Verify(() =>
+                        Then("the variable should be reset before the fourth Then, which sets it", () => Assert.That(timesSet++ == 0)));
                 });
         }
 
         protected override void AfterEachExample()
         {
             base.AfterEachExample();
-            timesCalled++;
+            timesSet = 0; 
         }
     }
 }

--- a/SpecEasy.Specs/BeforeEachAndAfterEachExampleSpecs/BeforeEachExampleCalledCorrectNumberOfTimesSpec.cs
+++ b/SpecEasy.Specs/BeforeEachAndAfterEachExampleSpecs/BeforeEachExampleCalledCorrectNumberOfTimesSpec.cs
@@ -5,12 +5,10 @@ namespace SpecEasy.Specs.SetUpAndTearDownSpecs
     public class BeforeEachExampleCalledCorrectNumberOfTimesSpec : Spec<FakeClass>
     {
         private int timesCalled = 0;
-        private int verifyCall = 0;
+        private int verifyCall = 1;
+
         public void CountBeforeEachExampleCalls()
         {
-            timesCalled = 0;
-            verifyCall = 1;
-
             When("running a test that overrides BeforeEachExample", () => Assert.That(timesCalled, Is.EqualTo(verifyCall)));
 
             Then("it should only call BeforeEachExample once to start with", () => Assert.That(timesCalled, Is.EqualTo(verifyCall++)));
@@ -28,9 +26,6 @@ namespace SpecEasy.Specs.SetUpAndTearDownSpecs
 
         public void NestedGivenBeforeEachExampleCalls()
         {
-            timesCalled = 0;
-            verifyCall = 1;
-
             When("running a test that overrides BeforeEachExample", () => Assert.That(timesCalled, Is.EqualTo(verifyCall)));
 
             Given("there is a first level of given methods", () => Assert.That(timesCalled, Is.EqualTo(verifyCall))).Verify(() => 

--- a/SpecEasy.Specs/GivenCount/GivenCountSpecs.cs
+++ b/SpecEasy.Specs/GivenCount/GivenCountSpecs.cs
@@ -6,59 +6,58 @@ namespace SpecEasy.Specs.GivenCount
 {
     public class GivenCountSpecs : Spec<FakeClass>
     {
-        private List<string> _givenCalls;
 
         public void GivensAreCalledOncePerThenInTheProperOrderWithSimpleNestingSpec()
         {
-            _givenCalls = new List<string>();
+            var givenCalls = new List<string>();
             When("running a test that has nested givens preceding a then", () => SUT.DoNothing());
 
-            Given("a given is called at nesting level 0.", () => _givenCalls.Add("0")).Verify(() =>
-                Given("a given is called at nesting level 1", () => _givenCalls.Add("1")).Verify(() =>
-                    Given("a given is called at nesting level 2", () => _givenCalls.Add("2")).Verify(() =>
+            Given("a given is called at nesting level 0.", () => givenCalls.Add("0")).Verify(() =>
+                Given("a given is called at nesting level 1", () => givenCalls.Add("1")).Verify(() =>
+                    Given("a given is called at nesting level 2", () => givenCalls.Add("2")).Verify(() =>
                             Then("each given should have been called only once and in the proper order", () => 
-                                VerifyGivenCalls("0 -> 1 -> 2", clearValuesAfterVerify: false)).
+                                VerifyGivenCalls(givenCalls, "0 -> 1 -> 2", clearValuesAfterVerify: false)).
                            Then("each given is called a second time for the second then", () => 
-                               VerifyGivenCalls("0 -> 1 -> 2 -> 0 -> 1 -> 2", clearValuesAfterVerify: false)))));
+                               VerifyGivenCalls(givenCalls, "0 -> 1 -> 2 -> 0 -> 1 -> 2", clearValuesAfterVerify: false)))));
         }
 
         public void GivensAreCalledOncePerThenInTheProperOrderWithMixedNestingSpec()
         {
-            _givenCalls = new List<string>();
+            var givenCalls = new List<string>();
 
             When("running a test that has nested givens at varying levels with then calls intertwined.", () => SUT.DoNothing());
 
-            Given("a top level given is used to establish 'global' context for the spec", () => _givenCalls.Add("0")).Verify(() =>
+            Given("a top level given is used to establish 'global' context for the spec", () => givenCalls.Add("0")).Verify(() =>
                 {
-                    Given("a nested given is used at level 1.1", () => _givenCalls.Add("1.1")).Verify(() =>
-                        Given("a nested given is used at level 2.1", () => _givenCalls.Add("2.1")).Verify(() =>
+                    Given("a nested given is used at level 1.1", () => givenCalls.Add("1.1")).Verify(() =>
+                        Given("a nested given is used at level 2.1", () => givenCalls.Add("2.1")).Verify(() =>
                         Then("each given should be called once leading up to this then", () =>
-                            VerifyGivenCalls("0 -> 1.1 -> 2.1"))));
+                            VerifyGivenCalls(givenCalls, "0 -> 1.1 -> 2.1"))));
 
-                    Given("a nested given is used at level 1.2", () => _givenCalls.Add("1.2")).Verify(() =>
+                    Given("a nested given is used at level 1.2", () => givenCalls.Add("1.2")).Verify(() =>
                         {
-                            Given("a nested given is used at level 2.2", () => _givenCalls.Add("2.2")).Verify(() =>
+                            Given("a nested given is used at level 2.2", () => givenCalls.Add("2.2")).Verify(() =>
                                 Then("each given leading up to this then should be called once.", () =>
-                                    VerifyGivenCalls("0 -> 1.2 -> 2.2")));
+                                    VerifyGivenCalls(givenCalls, "0 -> 1.2 -> 2.2")));
 
-                            Given("a nested given is used at level 2.3", () => _givenCalls.Add("2.3")).Verify(() =>
-                                Given("a nested given is used at level 3.1", () => _givenCalls.Add("3.1")).Verify(() =>
+                            Given("a nested given is used at level 2.3", () => givenCalls.Add("2.3")).Verify(() =>
+                                Given("a nested given is used at level 3.1", () => givenCalls.Add("3.1")).Verify(() =>
                                     {
                                         Then("all givens leading up to this then should be called once in the proper order.", () =>
-                                            VerifyGivenCalls("0 -> 1.2 -> 2.3 -> 3.1", clearValuesAfterVerify: true));
+                                            VerifyGivenCalls(givenCalls, "0 -> 1.2 -> 2.3 -> 3.1", clearValuesAfterVerify: true));
 
                                         Then("a second then immediately following the first should repeat the same givens in the same order.", () =>
-                                            VerifyGivenCalls("0 -> 1.2 -> 2.3 -> 3.1"));
+                                            VerifyGivenCalls(givenCalls, "0 -> 1.2 -> 2.3 -> 3.1"));
                                     }));
                         });
                 });
         }
 
-        private void VerifyGivenCalls(string expectedValue, bool clearValuesAfterVerify = true)
+        private void VerifyGivenCalls(List<string> givenCalls, string expectedValue, bool clearValuesAfterVerify = true)
         {
-            var givenCallListString = string.Join(" -> ", _givenCalls);
+            var givenCallListString = string.Join(" -> ", givenCalls);
             Assert.That(givenCallListString, Is.EqualTo(expectedValue));
-            if (clearValuesAfterVerify) _givenCalls.Clear();
+            if (clearValuesAfterVerify) givenCalls.Clear();
         }
     }
 }


### PR DESCRIPTION
By using a test case source, and building up an Action object to run for
each test case, each test case can display as a separate test in NUnit.
Reporting can be done more easily, as the NUnit reporting is now fairly
complete, although individual tests don't display very well in the tree
view. It also makes it possible to filter out the tests on the Spec
class itself, thus making full test runs against the SpecEasy solution
possible. If we were to remove the ability to check exceptions in a
delegate, and just have an expected exception type, we could also use the
NUnit expected exception handling.

Note that this does have some interesting side effects. First of all,
because tests are completely built up in advance, test order is less tied
to order in the code, and so should not be relied on. Additionally, test
code that is not in a Given/When/Then will get run during test
construction, but not during test execution. So member variables that are
reset in test code outside of a given/when/then no longer work. The tests
that relied on this behavior have been fixed in this change, but other code
may rely on it as well, and would need to be changed accordingly. Overall,
this is a good change, as it more clearly delineates code executed during
tests and code executed to create the test cases.

Pic of the SpecEasy test output in VS/Resharper before the changes:
![image](https://f.cloud.github.com/assets/142136/1315600/00147d28-3289-11e3-913f-e3919c4c7dc3.png)

Pic of the SpecEasy test output in VS/Resharper with the changes (note the lack of test failures):
![image](https://f.cloud.github.com/assets/142136/1315580/a35923f4-3288-11e3-907c-6e317c4d3cb5.png)
