### PR TITLE
Support for Async Methods

### DIFF
--- a/SpecEasy.Specs/Async/AsyncSpec.cs
+++ b/SpecEasy.Specs/Async/AsyncSpec.cs
@@ -1,0 +1,79 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Data.SqlServerCe;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using NUnit.Framework;
+using Rhino.Mocks;
+using Rhino.Mocks.Impl.Invocation.Specifications;
+
+namespace SpecEasy.Specs.Async
+{
+    public class AsyncSpec : Spec<AsyncTester>
+    {
+        private const string Name = "placeholder";
+        private const string Value = "The quick brown fox jumped over the lazy dog.";
+     
+        public void ReturnOne()
+        {
+            string result = string.Empty;
+            string intermediate = string.Empty;
+            int count = 1;
+
+            When("loading", async () => result = await SUT.LoadAsync(Name).ConfigureAwait(false));
+
+            Given("a value has been saved", () => Get<IPersistence>().Stub(persistence => persistence.LoadAsync(Name)).Return(Task.Factory.StartNew(() => Value))).Verify(() =>
+            {
+                Then("the desired value is loaded", () => Assert.AreEqual(result, Value));
+
+                Given("the persistence tracks the load count", ()=> Get<IPersistence>().Stub(persistence => persistence.GetLoadCountAsync()).Return(Task.Factory.StartNew(()=>count))).Verify(()=>
+                    Then("the number of loads can be retrieved", async () => Assert.AreEqual(count, await SUT.GetLoadCountAsync().ConfigureAwait(false))));
+            });
+
+            Given("there is an error loading the value", () => Get<IPersistence>().Stub(persistence => persistence.LoadAsync(Name)).Throw(new InvalidOperationException())).Verify(() =>
+                Then("an exception is thrown", () => AssertWasThrown<InvalidOperationException>()));
+
+            Given("the data was previously persisted", async () =>
+            {
+                Get<IPersistence>().Stub(persistence => persistence.SaveAsync(Arg<string>.Is.Equal(Name), Arg<string>.Is.Anything)).Return(Task.Factory.StartNew(() => { })).WhenCalled(x => intermediate = (string)x.Arguments[1]);
+                await SUT.SaveAsync(Name, Value).ConfigureAwait(false);
+            }).Verify(() =>
+                Given("the data is then loaded", () => Get<IPersistence>().Stub(persistence => persistence.LoadAsync(Name)).Return(Task.Factory.StartNew(() => intermediate))).Verify(() =>
+                    Then("the previously stored data is retrieved", () => Assert.AreEqual(result, Value))));
+        }
+    }
+
+    public class AsyncTester
+    {
+        private readonly IPersistence stubInterface;
+        public AsyncTester(IPersistence stubInterface)
+        {
+            this.stubInterface = stubInterface;
+        }
+
+        public async Task<string> LoadAsync(string name)
+        {
+            return await stubInterface.LoadAsync(name).ConfigureAwait(false);
+        }
+
+        public async Task<int> GetLoadCountAsync()
+        {
+            return await stubInterface.GetLoadCountAsync().ConfigureAwait(false);
+        }
+
+        public async Task SaveAsync(string name, string value)
+        {
+            await stubInterface.SaveAsync(name, value).ConfigureAwait(false);
+        }
+    }
+
+    public interface IPersistence
+    {
+        Task<string> LoadAsync(string name);
+
+        Task SaveAsync(string name, string value);
+
+        Task<int> GetLoadCountAsync();
+    }
+}

--- a/SpecEasy.Specs/SpecEasy.Specs.csproj
+++ b/SpecEasy.Specs/SpecEasy.Specs.csproj
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -9,7 +9,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>SpecEasy.Specs</RootNamespace>
     <AssemblyName>SpecEasy.Specs</AssemblyName>
-    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5.1</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\</SolutionDir>
     <RestorePackages>true</RestorePackages>
@@ -28,6 +28,7 @@
     <IsWebBootstrapper>false</IsWebBootstrapper>
     <UseApplicationTrust>false</UseApplicationTrust>
     <BootstrapperEnabled>true</BootstrapperEnabled>
+    <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -37,6 +38,7 @@
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
@@ -45,15 +47,16 @@
     <DefineConstants>TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Dapper, Version=1.12.1.1, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\Dapper.1.13\lib\net40\Dapper.dll</HintPath>
+      <HintPath>..\packages\Dapper.1.13\lib\net45\Dapper.dll</HintPath>
     </Reference>
-    <Reference Include="nunit.framework, Version=2.6.2.12296, Culture=neutral, PublicKeyToken=96d09a1eb7f44a77, processorArchitecture=MSIL">
+    <Reference Include="nunit.framework, Version=2.6.3.13283, Culture=neutral, PublicKeyToken=96d09a1eb7f44a77, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\NUnit.2.6.2\lib\nunit.framework.dll</HintPath>
+      <HintPath>..\packages\NUnit.2.6.3\lib\nunit.framework.dll</HintPath>
     </Reference>
     <Reference Include="Rhino.Mocks, Version=3.6.0.0, Culture=neutral, PublicKeyToken=0b3305902db7183f, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
@@ -74,6 +77,7 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Async\AsyncSpec.cs" />
     <Compile Include="BeforeEachAndAfterEachExampleSpecs\AfterEachExampleGetsCalledSpec.cs" />
     <Compile Include="BeforeEachAndAfterEachExampleSpecs\BeforeEachExampleCalledCorrectNumberOfTimesSpec.cs" />
     <Compile Include="BeforeEachAndAfterEachExampleSpecs\BeforeEachExampleGetsCalledSpec.cs" />

--- a/SpecEasy.Specs/packages.config
+++ b/SpecEasy.Specs/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Dapper" version="1.13" targetFramework="net40" />
-  <package id="NUnit" version="2.6.2" targetFramework="net40" />
+  <package id="Dapper" version="1.13" targetFramework="net451" />
+  <package id="NUnit" version="2.6.3" targetFramework="net451" />
   <package id="RhinoMocks" version="3.6.1" targetFramework="net40" />
 </packages>

--- a/SpecEasy/SpecEasy.csproj
+++ b/SpecEasy/SpecEasy.csproj
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" ToolsVersion="4.0">
+<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" ToolsVersion="12.0">
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
@@ -10,7 +10,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>SpecEasy</RootNamespace>
     <AssemblyName>SpecEasy</AssemblyName>
-    <TargetFrameworkVersion>v3.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5.1</TargetFrameworkVersion>
     <FileUpgradeFlags>
     </FileUpgradeFlags>
     <UpgradeBackupLocation>
@@ -33,6 +33,7 @@
     <BootstrapperEnabled>true</BootstrapperEnabled>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\</SolutionDir>
     <RestorePackages>true</RestorePackages>
+    <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -43,6 +44,7 @@
     <ErrorReport>prompt</ErrorReport>
     <FileAlignment>512</FileAlignment>
     <WarningLevel>4</WarningLevel>
+    <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
@@ -52,12 +54,13 @@
     <ErrorReport>prompt</ErrorReport>
     <FileAlignment>512</FileAlignment>
     <WarningLevel>4</WarningLevel>
+    <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="mscorlib" />
-    <Reference Include="nunit.framework, Version=2.6.2.12296, Culture=neutral, PublicKeyToken=96d09a1eb7f44a77, processorArchitecture=MSIL">
+    <Reference Include="nunit.framework, Version=2.6.3.13283, Culture=neutral, PublicKeyToken=96d09a1eb7f44a77, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\NUnit.2.6.2\lib\nunit.framework.dll</HintPath>
+      <HintPath>..\packages\NUnit.2.6.3\lib\nunit.framework.dll</HintPath>
     </Reference>
     <Reference Include="Rhino.Mocks, Version=3.6.0.0, Culture=neutral, PublicKeyToken=0b3305902db7183f, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>


### PR DESCRIPTION
Adds support for testing of async methods in .Net 4.5. Async can be used in When, Given and Then statements. The existing synchronous versions are wrapped in a Func<Task> and use of await causes them to be executed synchronously, thus, there is no behavior change for existing Specs.

@rockhymas 
