### PR TITLE
SpecEasy results hiding exceptions

### DIFF
--- a/.nuget/packages.config
+++ b/.nuget/packages.config
@@ -1,0 +1,4 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="NUnit.Runners" version="2.6.3" />
+</packages>

--- a/SpecEasy.Specs/ExceptionReporting/ExceptionReporting.cs
+++ b/SpecEasy.Specs/ExceptionReporting/ExceptionReporting.cs
@@ -1,0 +1,63 @@
+﻿using System;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using NUnit.Core.Filters;
+using Should;
+using SpecEasy;
+using NUnit.Core;
+using NUnit.Framework;
+
+namespace Examples
+{
+    [TestFixture]
+    public class ExceptionReportingSpecs
+    {
+
+        [Test]
+        public void RunSpecsForBrokenClass()
+        {
+            CoreExtensions.Host.InitializeService();
+            var pathToTestLibrary = Assembly.GetExecutingAssembly().Location;
+            var testPackage = new TestPackage(pathToTestLibrary)
+            {
+                BasePath = Path.GetDirectoryName(pathToTestLibrary)
+            };
+            var builder = new TestSuiteBuilder();
+            var suite = builder.Build(testPackage);
+            var filter = new SimpleNameFilter("Examples.BrokenClassSpec");
+            var result = suite.Run(new NullListener(), filter);
+
+            var failedTests = result.FindFailedTests();
+            Assert.IsTrue(failedTests.All(ft => ft.Message.StartsWith("System.Exception")), "At least one failed spec reported an assertion error when it should have reported an exception.");
+        }
+
+    }
+
+    internal class BrokenClassSpec : Spec<BrokenClass>
+    {
+        private bool input;
+        private bool result;
+
+        public void RunSpec()
+        {
+            When("inverting a boolean value", () => result = SUT.Invert(input));
+
+            Given("a false input", () => input = false).Verify(() =>
+                Then("the result is true", () => result.ShouldBeTrue()));
+
+            Given("a true input", () => input = true).Verify(() =>
+                Then("the result is false", () => result.ShouldBeFalse()));
+        }
+    }
+
+    public class BrokenClass
+    {
+        public bool Invert(bool value)
+        {
+            throw new Exception("exception while trying to invert value");
+            return !value;
+        }
+    }
+
+}

--- a/SpecEasy.Specs/ExceptionReporting/NUnitBrokenClassTests.cs
+++ b/SpecEasy.Specs/ExceptionReporting/NUnitBrokenClassTests.cs
@@ -1,0 +1,22 @@
+using NUnit.Framework;
+
+namespace Examples
+{
+    [TestFixture]
+    internal class NUnitBrokenClassTests
+    {
+        [Test]
+        public void GivenFalseItReturnsTrue()
+        {
+            var result = new BrokenClass().Invert(false);
+            Assert.IsTrue(result);
+        }
+
+        [Test]
+        public void GivenTrueItReturnsFalse()
+        {
+            var result = new BrokenClass().Invert(true);
+            Assert.IsFalse(result);
+        }
+    }
+}

--- a/SpecEasy.Specs/ExceptionReporting/TestResultExtensions.cs
+++ b/SpecEasy.Specs/ExceptionReporting/TestResultExtensions.cs
@@ -1,0 +1,19 @@
+﻿using System.Collections.Generic;
+using NUnit.Core;
+
+namespace Examples
+{
+    public static class TestResultExtensions
+    {
+        public static IEnumerable<TestResult> FindFailedTests(this TestResult testResult)
+        {
+            if (testResult.FailureSite == FailureSite.Test)
+                return new[] { testResult };
+
+            var failedTests = new List<TestResult>();
+            foreach (var childResult in testResult.Results)
+                failedTests.AddRange(FindFailedTests((TestResult)childResult));
+            return failedTests;
+        }
+    }
+}

--- a/SpecEasy.Specs/SpecEasy.Specs.csproj
+++ b/SpecEasy.Specs/SpecEasy.Specs.csproj
@@ -54,6 +54,12 @@
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\packages\Dapper.1.13\lib\net45\Dapper.dll</HintPath>
     </Reference>
+    <Reference Include="nunit.core">
+      <HintPath>..\packages\NUnit.Runners.2.6.3\tools\lib\nunit.core.dll</HintPath>
+    </Reference>
+    <Reference Include="nunit.core.interfaces">
+      <HintPath>..\packages\NUnit.Runners.2.6.3\tools\lib\nunit.core.interfaces.dll</HintPath>
+    </Reference>
     <Reference Include="nunit.framework, Version=2.6.3.13283, Culture=neutral, PublicKeyToken=96d09a1eb7f44a77, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\packages\NUnit.2.6.3\lib\nunit.framework.dll</HintPath>
@@ -88,6 +94,9 @@
     <Compile Include="BeforeEachAndAfterEachExampleSpecs\SutInBeforeEachExampleSpec.cs" />
     <Compile Include="DatabaseIntegration\DatabaseIntegrationSetup.cs" />
     <Compile Include="ExceptionAssertions\ExceptionAssertionsSpec.cs" />
+    <Compile Include="ExceptionReporting\ExceptionReporting.cs" />
+    <Compile Include="ExceptionReporting\NUnitBrokenClassTests.cs" />
+    <Compile Include="ExceptionReporting\TestResultExtensions.cs" />
     <Compile Include="FizzBuzz\FizzBuzzSpecs.cs" />
     <Compile Include="GenericSpec\AutoMockSpec.cs" />
     <Compile Include="GivenCount\GivenCountSpecs.cs" />

--- a/SpecEasy/Spec.cs
+++ b/SpecEasy/Spec.cs
@@ -104,7 +104,18 @@ namespace SpecEasy
                             thrownException = ex;
                         }
 
-                        await spec.Value().ConfigureAwait(false);
+                        try
+                        {
+                            await spec.Value().ConfigureAwait(false);
+                        }
+                        catch (Exception)
+                        {
+                            if (thrownException == null || exceptionAsserted)
+                            {
+                                exceptionAsserted = false;
+                                throw;
+                            }
+                        }
 
                         if (thrownException != null)
                         {
@@ -138,6 +149,7 @@ namespace SpecEasy
 
         protected void AssertWasThrown<T>(Action<T> expectation) where T : Exception
         {
+            exceptionAsserted = true;
             var expectedException = thrownException as T;
             if (expectedException == null)
                 throw new Exception("Expected exception was not thrown");
@@ -232,6 +244,7 @@ namespace SpecEasy
         }
 
         private Exception thrownException;
+        private bool exceptionAsserted;
 
         private void CreateMethodContexts()
         {

--- a/SpecEasy/Spec.cs
+++ b/SpecEasy/Spec.cs
@@ -92,6 +92,7 @@ namespace SpecEasy
                     try
                     {
                         var exceptionThrownAndAsserted = false;
+
                         await InitializeContext(contextListCapture).ConfigureAwait(false);
 
                         try
@@ -106,15 +107,13 @@ namespace SpecEasy
 
                         try
                         {
+                            exceptionAsserted = false;
                             await spec.Value().ConfigureAwait(false);
                         }
                         catch (Exception)
                         {
                             if (thrownException == null || exceptionAsserted)
-                            {
-                                exceptionAsserted = false;
                                 throw;
-                            }
                         }
 
                         if (thrownException != null)


### PR DESCRIPTION
**TL;DR**
SpecEasy results sometimes hide exceptions under bogus assertion errors. To fix this, I'm recommending that we replace `AssertWasThrown<T>` with a new mechanism for asserting exceptions. (Not included in this PR.)

**The Problem**
When the method under test throws an exception, SpecEasy sometimes reports the result incorrectly: it reports an assertion failure instead of the exception.

Consider the following SUT and spec:

```
public class BrokenClass {
    public bool Invert(bool value) {
        throw new Exception("exception while trying to invert value");
        return !value;
    }
}

class BrokenClassSpec : Spec<BrokenClass> {
    private bool input;
    private bool result;

    public void RunSpec() {
        When("inverting the value", () => result = SUT.Invert(input));

        Given("a true input", () => input = true).Verify(() =>
            Then("the result is false", () => result.ShouldBeFalse()));

        Given("a false input", () => input = false).Verify(() =>
            Then("the result is true", () => result.ShouldBeTrue()));
    }
}
```

The first spec correctly shows the exception. There is no assertion failure: SpecEasy evaluates the spec, but the assertion ‘passes’ (since false is the result variable’s default value).

The second spec incorrectly reports “Failed: Should.Core.Exceptions.TrueException : Assert.True() Failure”. SpecEasy always executes its specs, even if the SUT throws an exception during the When. (It appears to be doing this in order to support `AssertWasThrown<T>`.) It seems likely that the assertion failure overwrites or somehow takes priority over the exception that truly causes the failure.

This does not appear to be unique to the Resharper test runner: I ran the test case from my pull request using the native Nunit test running and got identical results.

**Possible Solutions**
- Add a new API, something along the lines of `ThenItThrows<T>(string, Action)` Store a flag indicating whether or not the spec in question asserts that an exception was thrown. If the "When" throws, only execute those specs flagged as asserting exceptions. This is a **breaking change**, and would render `AssertWasThrown<T>` unusable.
- Using a library like [Cecil](https://github.com/jbevain/cecil), modify the SpecEasy `Then` methods to inspect the Action (and Func<Task>). If it includes an `AssertWasThrown<T>` call, store a flag as outlined above.

I think the first option is the only realistic one. First, Cecil is not yet mature, and there don't seem to be any alternatives. Second, it wouldn't be airtight: SpecEasy would _only_ handle exception assertions using our API.

**The Test Demonstrating the Problem**
- In order to verify that the NUnit TestResults were correctly reporting exceptions, I used the following code: `ft.Message.StartsWith("System.Exception")`. I don’t like looking for strings, but there doesn't seem to be any other way of differentiating results that report assertion failures from results that report exceptions.
- If you debug and look at the test results in `ExceptionReportingSpecs.RunSpecsForBrokenClass`, you'll see that we get two test results per spec. This is not true for the NUnit equivalent.
  It looks like SpecEasy is building them twice, possibly due to the way the test harness is set up. It does not appear to influence the outcome
