### PR TITLE
Solution would not build in VS 2013 because of NuGet configuration error.

### DIFF
--- a/.nuget/NuGet.targets
+++ b/.nuget/NuGet.targets
@@ -132,7 +132,7 @@
         </Task>
     </UsingTask>
     
-     <UsingTask TaskName="SetEnvironmentVariable" TaskFactory="CodeTaskFactory" AssemblyFile="$(MSBuildToolsPath)\Microsoft.Build.Tasks.v12.0.dll">
+     <UsingTask TaskName="SetEnvironmentVariable" TaskFactory="CodeTaskFactory" AssemblyFile="$(MSBuildToolsPath)\Microsoft.Build.Tasks.v$(MSBuildToolsVersion).dll">
         <ParameterGroup>
             <EnvKey ParameterType="System.String" Required="true" />
             <EnvValue ParameterType="System.String" Required="true" />

--- a/.nuget/NuGet.targets
+++ b/.nuget/NuGet.targets
@@ -132,7 +132,7 @@
         </Task>
     </UsingTask>
     
-     <UsingTask TaskName="SetEnvironmentVariable" TaskFactory="CodeTaskFactory" AssemblyFile="$(MSBuildToolsPath)\Microsoft.Build.Tasks.v4.0.dll">
+     <UsingTask TaskName="SetEnvironmentVariable" TaskFactory="CodeTaskFactory" AssemblyFile="$(MSBuildToolsPath)\Microsoft.Build.Tasks.v12.0.dll">
         <ParameterGroup>
             <EnvKey ParameterType="System.String" Required="true" />
             <EnvValue ParameterType="System.String" Required="true" />


### PR DESCRIPTION
Encountered the following compile error on both projects: 

> `The task factory "CodeTaskFactory" could not be loaded from the assembly "C:\Program Files (x86)\MSBuild\12.0\bin\Microsoft.Build.Tasks.v4.0.dll". Could not load file or assembly 'file:///C:\Program Files (x86)\MSBuild\12.0\bin\Microsoft.Build.Tasks.v4.0.dll' or one of its dependencies. The system cannot find the file specified.`

NuGet target was using the correct tools path but the wrong Tasks dll name. See [this SO question](http://stackoverflow.com/questions/20661943/build-on-tfs-2013-failed-but-okay-locally).
