### PR TITLE
Keep NUnit at the same version between both projects

### DIFF
--- a/SpecEasy/packages.config
+++ b/SpecEasy/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="NUnit" version="2.6.2" targetFramework="net35" />
+  <package id="NUnit" version="2.6.3" targetFramework="net451" />
   <package id="RhinoMocks" version="3.6.1" targetFramework="net35" />
 </packages>


### PR DESCRIPTION
The SpecEasy project was at NUnit 2.6.2 and SpecEasy.Specs was at 2.6.3.  This required two version of Nunit to be restored by NuGet when only one is really needed.  I upgraded SpecEasy's `packages.config` to use version 2.6.3.

The target framework also was updated to 451 - would this be an issue?
