### PR TITLE
Added the ability to use NUnit's AssertionHelper in SpecEasy

### DIFF
--- a/SpecEasy/Spec.cs
+++ b/SpecEasy/Spec.cs
@@ -11,7 +11,7 @@ using NUnit.Framework;
 namespace SpecEasy
 {
     [TestFixture]
-    public class Spec
+    public class Spec : AssertionHelper
     {
         [Test, TestCaseSource("TestCases")]
         public async Task Verify(Func<Task> test)


### PR DESCRIPTION
This PR allows a user to use NUnit's `AssertionHelper`'s `Expect()` method instead of `Assert.That()`.  Saves a few characters and some feel that this is more descriptive.
