### PR TITLE
Add Support for .NET 4.5

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -67,6 +67,9 @@ DocProject/Help/html
 # Click-Once directory
 publish
 
+# Nuget package
+*.nupkg
+
 # Others
 [Bb]in
 [Oo]bj

--- a/.nuget/NuGet.targets
+++ b/.nuget/NuGet.targets
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project ToolsVersion="12.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
     <PropertyGroup>
         <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">$(MSBuildProjectDirectory)\..\</SolutionDir>
-        
+
         <!-- Enable the restore command to run before builds -->
         <RestorePackages Condition="  '$(RestorePackages)' == '' ">false</RestorePackages>
 
@@ -11,11 +11,11 @@
 
         <!-- Determines if package restore consent is required to restore packages -->
         <RequireRestoreConsent Condition=" '$(RequireRestoreConsent)' != 'false' ">true</RequireRestoreConsent>
-        
+
         <!-- Download NuGet.exe if it does not already exist -->
         <DownloadNuGetExe Condition=" '$(DownloadNuGetExe)' == '' ">false</DownloadNuGetExe>
     </PropertyGroup>
-    
+
     <ItemGroup Condition=" '$(PackageSources)' == '' ">
         <!-- Package sources used to restore packages. By default, registered sources under %APPDATA%\NuGet\NuGet.Config will be used -->
         <!-- The official NuGet package source (https://nuget.org/api/v2/) will be excluded if package sources are specified and it does not appear in the list -->
@@ -31,24 +31,24 @@
         <PackagesConfig>$([System.IO.Path]::Combine($(ProjectDir), "packages.config"))</PackagesConfig>
         <PackagesDir>$([System.IO.Path]::Combine($(SolutionDir), "packages"))</PackagesDir>
     </PropertyGroup>
-    
+
     <PropertyGroup Condition=" '$(OS)' != 'Windows_NT'">
         <!-- We need to launch nuget.exe with the mono command if we're not on windows -->
         <NuGetToolsPath>$(SolutionDir).nuget</NuGetToolsPath>
         <PackagesConfig>packages.config</PackagesConfig>
         <PackagesDir>$(SolutionDir)packages</PackagesDir>
     </PropertyGroup>
-    
+
     <PropertyGroup>
         <!-- NuGet command -->
         <NuGetExePath Condition=" '$(NuGetExePath)' == '' ">$(NuGetToolsPath)\nuget.exe</NuGetExePath>
         <PackageSources Condition=" $(PackageSources) == '' ">@(PackageSource)</PackageSources>
-        
+
         <NuGetCommand Condition=" '$(OS)' == 'Windows_NT'">"$(NuGetExePath)"</NuGetCommand>
         <NuGetCommand Condition=" '$(OS)' != 'Windows_NT' ">mono --runtime=v4.0.30319 $(NuGetExePath)</NuGetCommand>
 
         <PackageOutputDir Condition="$(PackageOutputDir) == ''">$(TargetDir.Trim('\\'))</PackageOutputDir>
-        
+
         <RequireConsentSwitch Condition=" $(RequireRestoreConsent) == 'true' ">-RequireConsent</RequireConsentSwitch>
         <!-- Commands -->
         <RestoreCommand>$(NuGetCommand) install "$(PackagesConfig)" -source "$(PackageSources)"  $(RequireConsentSwitch) -o "$(PackagesDir)"</RestoreCommand>
@@ -86,21 +86,21 @@
     <Target Name="RestorePackages" DependsOnTargets="CheckPrerequisites">
         <Exec Command="$(RestoreCommand)"
               Condition="'$(OS)' != 'Windows_NT' And Exists('$(PackagesConfig)')" />
-              
+
         <Exec Command="$(RestoreCommand)"
               LogStandardErrorAsError="true"
               Condition="'$(OS)' == 'Windows_NT' And Exists('$(PackagesConfig)')" />
     </Target>
 
     <Target Name="BuildPackage" DependsOnTargets="CheckPrerequisites">
-        <Exec Command="$(BuildCommand)" 
+        <Exec Command="$(BuildCommand)"
               Condition=" '$(OS)' != 'Windows_NT' " />
-              
+
         <Exec Command="$(BuildCommand)"
               LogStandardErrorAsError="true"
               Condition=" '$(OS)' == 'Windows_NT' " />
     </Target>
-    
+
     <UsingTask TaskName="DownloadNuGet" TaskFactory="CodeTaskFactory" AssemblyFile="$(MSBuildToolsPath)\Microsoft.Build.Tasks.v4.0.dll">
         <ParameterGroup>
             <OutputFilename ParameterType="System.String" Required="true" />
@@ -131,7 +131,7 @@
             </Code>
         </Task>
     </UsingTask>
-    
+
      <UsingTask TaskName="SetEnvironmentVariable" TaskFactory="CodeTaskFactory" AssemblyFile="$(MSBuildToolsPath)\Microsoft.Build.Tasks.v$(MSBuildToolsVersion).dll">
         <ParameterGroup>
             <EnvKey ParameterType="System.String" Required="true" />

--- a/.nuget/packages.config
+++ b/.nuget/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="NUnit.Runners" version="2.6.3" />
+  <package id="NUnit.Runners" version="2.6.4" />
 </packages>

--- a/SpecEasy.Specs/SpecEasy.Specs.csproj
+++ b/SpecEasy.Specs/SpecEasy.Specs.csproj
@@ -31,6 +31,7 @@
     <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <TargetFrameworkVersion>v4.5.1</TargetFrameworkVersion>
     <DebugSymbols>true</DebugSymbols>
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
@@ -41,6 +42,7 @@
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <TargetFrameworkVersion>v4.5.1</TargetFrameworkVersion>
     <DebugType>pdbonly</DebugType>
     <Optimize>true</Optimize>
     <OutputPath>bin\Release\</OutputPath>
@@ -48,6 +50,26 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <Prefer32Bit>false</Prefer32Bit>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug45|AnyCPU'">
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <DebugSymbols>true</DebugSymbols>
+    <OutputPath>bin\Debug45\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <DebugType>full</DebugType>
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <ErrorReport>prompt</ErrorReport>
+    <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release45|AnyCPU'">
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <OutputPath>bin\Release45\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <Optimize>true</Optimize>
+    <DebugType>pdbonly</DebugType>
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <ErrorReport>prompt</ErrorReport>
+    <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Dapper, Version=1.12.1.1, Culture=neutral, processorArchitecture=MSIL">

--- a/SpecEasy.Specs/SpecEasy.Specs.csproj
+++ b/SpecEasy.Specs/SpecEasy.Specs.csproj
@@ -2,7 +2,7 @@
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
-    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug 4.5.1</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
     <ProjectGuid>{101D8D3F-3FAD-4E2A-B483-32338C6E7EAB}</ProjectGuid>
     <OutputType>Library</OutputType>
@@ -30,7 +30,7 @@
     <BootstrapperEnabled>true</BootstrapperEnabled>
     <TargetFrameworkProfile />
   </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug 4.5.1|AnyCPU' ">
     <TargetFrameworkVersion>v4.5.1</TargetFrameworkVersion>
     <DebugSymbols>true</DebugSymbols>
     <DebugType>full</DebugType>
@@ -41,7 +41,7 @@
     <WarningLevel>4</WarningLevel>
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release 4.5.1|AnyCPU' ">
     <TargetFrameworkVersion>v4.5.1</TargetFrameworkVersion>
     <DebugType>pdbonly</DebugType>
     <Optimize>true</Optimize>
@@ -51,7 +51,7 @@
     <WarningLevel>4</WarningLevel>
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug45|AnyCPU'">
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug 4.5|AnyCPU' ">
     <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <DebugSymbols>true</DebugSymbols>
     <OutputPath>bin\Debug45\</OutputPath>
@@ -61,7 +61,7 @@
     <ErrorReport>prompt</ErrorReport>
     <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release45|AnyCPU'">
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release 4.5|AnyCPU' ">
     <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <OutputPath>bin\Release45\</OutputPath>
     <DefineConstants>TRACE</DefineConstants>
@@ -169,7 +169,7 @@
   <ItemGroup />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Import Project="$(SolutionDir)\.nuget\NuGet.targets" Condition="Exists('$(SolutionDir)\.nuget\NuGet.targets')" />
-  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it.
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">
   </Target>

--- a/SpecEasy.Specs/SpecEasy.Specs.csproj
+++ b/SpecEasy.Specs/SpecEasy.Specs.csproj
@@ -72,19 +72,21 @@
     <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Dapper, Version=1.12.1.1, Culture=neutral, processorArchitecture=MSIL">
+    <Reference Include="Dapper, Version=1.38.0.0, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\Dapper.1.13\lib\net45\Dapper.dll</HintPath>
+      <HintPath>..\packages\Dapper.1.38\lib\net45\Dapper.dll</HintPath>
     </Reference>
-    <Reference Include="nunit.core">
-      <HintPath>..\packages\NUnit.Runners.2.6.3\tools\lib\nunit.core.dll</HintPath>
-    </Reference>
-    <Reference Include="nunit.core.interfaces">
-      <HintPath>..\packages\NUnit.Runners.2.6.3\tools\lib\nunit.core.interfaces.dll</HintPath>
-    </Reference>
-    <Reference Include="nunit.framework, Version=2.6.3.13283, Culture=neutral, PublicKeyToken=96d09a1eb7f44a77, processorArchitecture=MSIL">
+    <Reference Include="nunit.core, Version=2.6.3.13283, Culture=neutral, PublicKeyToken=96d09a1eb7f44a77, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\NUnit.2.6.3\lib\nunit.framework.dll</HintPath>
+      <HintPath>..\packages\NUnit.Runners.2.6.4\tools\lib\nunit.core.dll</HintPath>
+    </Reference>
+    <Reference Include="nunit.core.interfaces, Version=2.6.3.13283, Culture=neutral, PublicKeyToken=96d09a1eb7f44a77, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\packages\NUnit.Runners.2.6.4\tools\lib\nunit.core.interfaces.dll</HintPath>
+    </Reference>
+    <Reference Include="nunit.framework, Version=2.6.4.14350, Culture=neutral, PublicKeyToken=96d09a1eb7f44a77, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\packages\NUnit.2.6.4\lib\nunit.framework.dll</HintPath>
     </Reference>
     <Reference Include="Rhino.Mocks, Version=3.6.0.0, Culture=neutral, PublicKeyToken=0b3305902db7183f, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>

--- a/SpecEasy.Specs/packages.config
+++ b/SpecEasy.Specs/packages.config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Dapper" version="1.13" targetFramework="net451" />
-  <package id="NUnit" version="2.6.3" targetFramework="net451" />
+  <package id="Dapper" version="1.38" targetFramework="net451" />
+  <package id="NUnit" version="2.6.4" targetFramework="net451" />
   <package id="RhinoMocks" version="3.6.1" targetFramework="net40" />
   <package id="Should" version="1.1.20" targetFramework="net451" />
 </packages>

--- a/SpecEasy.sln
+++ b/SpecEasy.sln
@@ -1,6 +1,8 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 2012
+# Visual Studio 2013
+VisualStudioVersion = 12.0.30723.0
+MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SpecEasy", "SpecEasy\SpecEasy.csproj", "{D15653FB-10A8-4ABB-BACD-A1694FC3251C}"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = ".nuget", ".nuget", "{6CDE290A-366A-4119-B8C2-AA8486DFBFB3}"
@@ -20,17 +22,27 @@ EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
+		Debug45|Any CPU = Debug45|Any CPU
 		Release|Any CPU = Release|Any CPU
+		Release45|Any CPU = Release45|Any CPU
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{D15653FB-10A8-4ABB-BACD-A1694FC3251C}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{D15653FB-10A8-4ABB-BACD-A1694FC3251C}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{D15653FB-10A8-4ABB-BACD-A1694FC3251C}.Debug45|Any CPU.ActiveCfg = Debug45|Any CPU
+		{D15653FB-10A8-4ABB-BACD-A1694FC3251C}.Debug45|Any CPU.Build.0 = Debug45|Any CPU
 		{D15653FB-10A8-4ABB-BACD-A1694FC3251C}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{D15653FB-10A8-4ABB-BACD-A1694FC3251C}.Release|Any CPU.Build.0 = Release|Any CPU
+		{D15653FB-10A8-4ABB-BACD-A1694FC3251C}.Release45|Any CPU.ActiveCfg = Release45|Any CPU
+		{D15653FB-10A8-4ABB-BACD-A1694FC3251C}.Release45|Any CPU.Build.0 = Release45|Any CPU
 		{101D8D3F-3FAD-4E2A-B483-32338C6E7EAB}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{101D8D3F-3FAD-4E2A-B483-32338C6E7EAB}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{101D8D3F-3FAD-4E2A-B483-32338C6E7EAB}.Debug45|Any CPU.ActiveCfg = Debug45|Any CPU
+		{101D8D3F-3FAD-4E2A-B483-32338C6E7EAB}.Debug45|Any CPU.Build.0 = Debug45|Any CPU
 		{101D8D3F-3FAD-4E2A-B483-32338C6E7EAB}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{101D8D3F-3FAD-4E2A-B483-32338C6E7EAB}.Release|Any CPU.Build.0 = Release|Any CPU
+		{101D8D3F-3FAD-4E2A-B483-32338C6E7EAB}.Release45|Any CPU.ActiveCfg = Release45|Any CPU
+		{101D8D3F-3FAD-4E2A-B483-32338C6E7EAB}.Release45|Any CPU.Build.0 = Release45|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/SpecEasy.sln
+++ b/SpecEasy.sln
@@ -8,8 +8,6 @@ EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = ".nuget", ".nuget", "{6CDE290A-366A-4119-B8C2-AA8486DFBFB3}"
 	ProjectSection(SolutionItems) = preProject
 		.nuget\NuGet.Config = .nuget\NuGet.Config
-		.nuget\NuGet.exe = .nuget\NuGet.exe
-		.nuget\NuGet.targets = .nuget\NuGet.targets
 	EndProjectSection
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Build", "Build", "{56D50E15-4FAE-4C84-B53D-7D279E42A509}"

--- a/SpecEasy.sln
+++ b/SpecEasy.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 2013
-VisualStudioVersion = 12.0.30723.0
+VisualStudioVersion = 12.0.31101.0
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SpecEasy", "SpecEasy\SpecEasy.csproj", "{D15653FB-10A8-4ABB-BACD-A1694FC3251C}"
 EndProject
@@ -21,28 +21,28 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SpecEasy.Specs", "SpecEasy.
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
-		Debug|Any CPU = Debug|Any CPU
-		Debug45|Any CPU = Debug45|Any CPU
-		Release|Any CPU = Release|Any CPU
-		Release45|Any CPU = Release45|Any CPU
+		Debug 4.5.1|Any CPU = Debug 4.5.1|Any CPU
+		Debug 4.5|Any CPU = Debug 4.5|Any CPU
+		Release 4.5.1|Any CPU = Release 4.5.1|Any CPU
+		Release 4.5|Any CPU = Release 4.5|Any CPU
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
-		{D15653FB-10A8-4ABB-BACD-A1694FC3251C}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{D15653FB-10A8-4ABB-BACD-A1694FC3251C}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{D15653FB-10A8-4ABB-BACD-A1694FC3251C}.Debug45|Any CPU.ActiveCfg = Debug45|Any CPU
-		{D15653FB-10A8-4ABB-BACD-A1694FC3251C}.Debug45|Any CPU.Build.0 = Debug45|Any CPU
-		{D15653FB-10A8-4ABB-BACD-A1694FC3251C}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{D15653FB-10A8-4ABB-BACD-A1694FC3251C}.Release|Any CPU.Build.0 = Release|Any CPU
-		{D15653FB-10A8-4ABB-BACD-A1694FC3251C}.Release45|Any CPU.ActiveCfg = Release45|Any CPU
-		{D15653FB-10A8-4ABB-BACD-A1694FC3251C}.Release45|Any CPU.Build.0 = Release45|Any CPU
-		{101D8D3F-3FAD-4E2A-B483-32338C6E7EAB}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{101D8D3F-3FAD-4E2A-B483-32338C6E7EAB}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{101D8D3F-3FAD-4E2A-B483-32338C6E7EAB}.Debug45|Any CPU.ActiveCfg = Debug45|Any CPU
-		{101D8D3F-3FAD-4E2A-B483-32338C6E7EAB}.Debug45|Any CPU.Build.0 = Debug45|Any CPU
-		{101D8D3F-3FAD-4E2A-B483-32338C6E7EAB}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{101D8D3F-3FAD-4E2A-B483-32338C6E7EAB}.Release|Any CPU.Build.0 = Release|Any CPU
-		{101D8D3F-3FAD-4E2A-B483-32338C6E7EAB}.Release45|Any CPU.ActiveCfg = Release45|Any CPU
-		{101D8D3F-3FAD-4E2A-B483-32338C6E7EAB}.Release45|Any CPU.Build.0 = Release45|Any CPU
+		{D15653FB-10A8-4ABB-BACD-A1694FC3251C}.Debug 4.5.1|Any CPU.ActiveCfg = Debug 4.5.1|Any CPU
+		{D15653FB-10A8-4ABB-BACD-A1694FC3251C}.Debug 4.5.1|Any CPU.Build.0 = Debug 4.5.1|Any CPU
+		{D15653FB-10A8-4ABB-BACD-A1694FC3251C}.Debug 4.5|Any CPU.ActiveCfg = Debug 4.5|Any CPU
+		{D15653FB-10A8-4ABB-BACD-A1694FC3251C}.Debug 4.5|Any CPU.Build.0 = Debug 4.5|Any CPU
+		{D15653FB-10A8-4ABB-BACD-A1694FC3251C}.Release 4.5.1|Any CPU.ActiveCfg = Release 4.5.1|Any CPU
+		{D15653FB-10A8-4ABB-BACD-A1694FC3251C}.Release 4.5.1|Any CPU.Build.0 = Release 4.5.1|Any CPU
+		{D15653FB-10A8-4ABB-BACD-A1694FC3251C}.Release 4.5|Any CPU.ActiveCfg = Release 4.5|Any CPU
+		{D15653FB-10A8-4ABB-BACD-A1694FC3251C}.Release 4.5|Any CPU.Build.0 = Release 4.5|Any CPU
+		{101D8D3F-3FAD-4E2A-B483-32338C6E7EAB}.Debug 4.5.1|Any CPU.ActiveCfg = Debug 4.5.1|Any CPU
+		{101D8D3F-3FAD-4E2A-B483-32338C6E7EAB}.Debug 4.5.1|Any CPU.Build.0 = Debug 4.5.1|Any CPU
+		{101D8D3F-3FAD-4E2A-B483-32338C6E7EAB}.Debug 4.5|Any CPU.ActiveCfg = Debug 4.5|Any CPU
+		{101D8D3F-3FAD-4E2A-B483-32338C6E7EAB}.Debug 4.5|Any CPU.Build.0 = Debug 4.5|Any CPU
+		{101D8D3F-3FAD-4E2A-B483-32338C6E7EAB}.Release 4.5.1|Any CPU.ActiveCfg = Release 4.5.1|Any CPU
+		{101D8D3F-3FAD-4E2A-B483-32338C6E7EAB}.Release 4.5.1|Any CPU.Build.0 = Release 4.5.1|Any CPU
+		{101D8D3F-3FAD-4E2A-B483-32338C6E7EAB}.Release 4.5|Any CPU.ActiveCfg = Release 4.5|Any CPU
+		{101D8D3F-3FAD-4E2A-B483-32338C6E7EAB}.Release 4.5|Any CPU.Build.0 = Release 4.5|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/SpecEasy/Context.cs
+++ b/SpecEasy/Context.cs
@@ -5,8 +5,6 @@ namespace SpecEasy
 {
     public interface IContext
     {
-        void Verify(Func<Task> addSpecs);
-
         void Verify(Action addSpecs);
     }
 
@@ -30,15 +28,10 @@ namespace SpecEasy
             enterAction = addSpecs;
         }
 
-        public void Verify(Func<Task> addSpecs)
-        {
-            var cachedEnterAction = enterAction;
-            enterAction = async () => { cachedEnterAction(); addSpecs(); };
-        }
-
         public void Verify(Action addSpecs)
         {
-            Verify(async () => addSpecs());
+            var cachedEnterAction = enterAction;
+            enterAction = () => { cachedEnterAction(); addSpecs(); };
         }
         
         public void EnterContext()

--- a/SpecEasy/Properties/AssemblyInfo.cs
+++ b/SpecEasy/Properties/AssemblyInfo.cs
@@ -5,7 +5,7 @@ using System.Runtime.InteropServices;
 // set of attributes. Change these attribute values to modify the information
 // associated with an assembly.
 [assembly: AssemblyTitle("SpecEasy")]
-[assembly: AssemblyDescription("Specifications made easy")]
+[assembly: AssemblyDescription("Specifications made easy.")]
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("TrackAbout, Inc.")]
 [assembly: AssemblyProduct("SpecEasy")]
@@ -30,5 +30,5 @@ using System.Runtime.InteropServices;
 //
 // You can specify all the values or you can default the Revision and Build Numbers 
 // by using the '*' as shown below:
-[assembly: AssemblyVersion("2.0.0.0")]
+[assembly: AssemblyVersion("2.0.1.0")]
 

--- a/SpecEasy/Properties/AssemblyInfo.cs
+++ b/SpecEasy/Properties/AssemblyInfo.cs
@@ -1,7 +1,7 @@
 ﻿using System.Reflection;
 using System.Runtime.InteropServices;
 
-// General Information about an assembly is controlled through the following 
+// General Information about an assembly is controlled through the following
 // set of attributes. Change these attribute values to modify the information
 // associated with an assembly.
 [assembly: AssemblyTitle("SpecEasy")]
@@ -13,8 +13,8 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 
-// Setting ComVisible to false makes the types in this assembly not visible 
-// to COM components.  If you need to access a type in this assembly from 
+// Setting ComVisible to false makes the types in this assembly not visible
+// to COM components.  If you need to access a type in this assembly from
 // COM, set the ComVisible attribute to true on that type.
 [assembly: ComVisible(false)]
 
@@ -24,11 +24,10 @@ using System.Runtime.InteropServices;
 // Version information for an assembly consists of the following four values:
 //
 //      Major Version
-//      Minor Version 
+//      Minor Version
 //      Build Number
 //      Revision
 //
-// You can specify all the values or you can default the Revision and Build Numbers 
+// You can specify all the values or you can default the Revision and Build Numbers
 // by using the '*' as shown below:
-[assembly: AssemblyVersion("2.0.1.0")]
-
+[assembly: AssemblyVersion("2.1.0.0")]

--- a/SpecEasy/SpecEasy.csproj
+++ b/SpecEasy/SpecEasy.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" ToolsVersion="12.0">
   <PropertyGroup>
-    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Configuration Condition=" '$(Configuration)' == '' ">Release 4.5.1</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
     <ProductVersion>9.0.30729</ProductVersion>
     <SchemaVersion>2.0</SchemaVersion>
@@ -35,7 +35,7 @@
     <RestorePackages>true</RestorePackages>
     <TargetFrameworkProfile />
   </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug 4.5.1|AnyCPU' ">
     <TargetFrameworkVersion>v4.5.1</TargetFrameworkVersion>
     <DebugSymbols>true</DebugSymbols>
     <DebugType>full</DebugType>
@@ -47,7 +47,7 @@
     <WarningLevel>4</WarningLevel>
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release 4.5.1|AnyCPU' ">
     <TargetFrameworkVersion>v4.5.1</TargetFrameworkVersion>
     <DebugType>pdbonly</DebugType>
     <Optimize>true</Optimize>
@@ -58,7 +58,7 @@
     <WarningLevel>4</WarningLevel>
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug45|AnyCPU'">
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug 4.5|AnyCPU' ">
     <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <DebugSymbols>true</DebugSymbols>
     <OutputPath>bin\Debug45\</OutputPath>
@@ -68,7 +68,7 @@
     <ErrorReport>prompt</ErrorReport>
     <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release45|AnyCPU'">
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release 4.5|AnyCPU' ">
     <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <OutputPath>bin\Release45\</OutputPath>
     <DefineConstants>TRACE</DefineConstants>
@@ -128,7 +128,7 @@
       </FlavorProperties>
     </VisualStudio>
   </ProjectExtensions>
-  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it.
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">
   </Target>

--- a/SpecEasy/SpecEasy.csproj
+++ b/SpecEasy/SpecEasy.csproj
@@ -80,9 +80,9 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="mscorlib" />
-    <Reference Include="nunit.framework, Version=2.6.3.13283, Culture=neutral, PublicKeyToken=96d09a1eb7f44a77, processorArchitecture=MSIL">
+    <Reference Include="nunit.framework, Version=2.6.4.14350, Culture=neutral, PublicKeyToken=96d09a1eb7f44a77, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\NUnit.2.6.3\lib\nunit.framework.dll</HintPath>
+      <HintPath>..\packages\NUnit.2.6.4\lib\nunit.framework.dll</HintPath>
     </Reference>
     <Reference Include="Rhino.Mocks, Version=3.6.0.0, Culture=neutral, PublicKeyToken=0b3305902db7183f, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>

--- a/SpecEasy/SpecEasy.csproj
+++ b/SpecEasy/SpecEasy.csproj
@@ -36,6 +36,7 @@
     <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <TargetFrameworkVersion>v4.5.1</TargetFrameworkVersion>
     <DebugSymbols>true</DebugSymbols>
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
@@ -47,6 +48,7 @@
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <TargetFrameworkVersion>v4.5.1</TargetFrameworkVersion>
     <DebugType>pdbonly</DebugType>
     <Optimize>true</Optimize>
     <OutputPath>bin\Release\</OutputPath>
@@ -55,6 +57,26 @@
     <FileAlignment>512</FileAlignment>
     <WarningLevel>4</WarningLevel>
     <Prefer32Bit>false</Prefer32Bit>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug45|AnyCPU'">
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <DebugSymbols>true</DebugSymbols>
+    <OutputPath>bin\Debug45\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <DebugType>full</DebugType>
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <ErrorReport>prompt</ErrorReport>
+    <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release45|AnyCPU'">
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <OutputPath>bin\Release45\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <Optimize>true</Optimize>
+    <DebugType>pdbonly</DebugType>
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <ErrorReport>prompt</ErrorReport>
+    <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="mscorlib" />

--- a/SpecEasy/SpecEasy.nuspec
+++ b/SpecEasy/SpecEasy.nuspec
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<package >
+<package>
   <metadata>
     <id>$id$</id>
     <version>$version$</version>
@@ -12,11 +12,17 @@
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>$description$</description>
     <releaseNotes>
-Version 2.0.0 of SpecEasy introduces support for testing async methods. 
-Note that this version requires .NET 4.5.1 and includes a breaking change from the 1.0.0 release as described here:
-https://github.com/trackabout/speceasy/pull/23#issuecomment-32572855
+Version 2.0.1 of SpecEasy includes:
+  - A fix that prevents exceptions in the method under test from being ignored when there is also an assertion failure. See https://github.com/trackabout/speceasy/pull/24.
+  - Support for .NET 4.5 in addition to the existing .NET 4.5.1 support.
+  - Several other minor fixes.
     </releaseNotes>
-    <copyright>Copyright 2013</copyright>
+    <copyright>Copyright 2015</copyright>
     <tags>bdd tdd unit test testing fluent</tags>
   </metadata>
+  <files>
+    <!-- Do not need to include .NET 4.5.1 version here because nuget automatically adds the output of
+         either the default build configuration or the configuration specified when running the pack command. -->
+    <file src="..\SpecEasy\bin\Release45\$id$.dll" target="lib\net45\" />
+  </files>
 </package>

--- a/SpecEasy/SpecEasy.nuspec
+++ b/SpecEasy/SpecEasy.nuspec
@@ -12,7 +12,7 @@
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>$description$</description>
     <releaseNotes>
-Version 2.0.1 of SpecEasy includes:
+Version 2.1.0 of SpecEasy includes:
   - A fix that prevents exceptions in the method under test from being ignored when there is also an assertion failure. See https://github.com/trackabout/speceasy/pull/24.
   - Support for .NET 4.5 in addition to the existing .NET 4.5.1 support.
   - Several other minor fixes.

--- a/SpecEasy/packages.config
+++ b/SpecEasy/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="NUnit" version="2.6.2" targetFramework="net35" />
+  <package id="NUnit" version="2.6.3" targetFramework="net451" />
   <package id="RhinoMocks" version="3.6.1" targetFramework="net35" />
 </packages>

--- a/SpecEasy/packages.config
+++ b/SpecEasy/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="NUnit" version="2.6.3" targetFramework="net451" />
+  <package id="NUnit" version="2.6.4" targetFramework="net451" />
   <package id="RhinoMocks" version="3.6.1" targetFramework="net35" />
 </packages>

--- a/build/build.nuget.bat
+++ b/build/build.nuget.bat
@@ -1,0 +1,6 @@
+SET MSBUILD=C:\Windows\Microsoft.NET\Framework\v4.0.30319\msbuild.exe
+
+%MSBUILD% ..\SpecEasy.sln /target:Rebuild /p:Configuration="Release 4.5"
+%MSBUILD% ..\SpecEasy.sln /target:Rebuild /p:Configuration="Release 4.5.1"
+
+..\.nuget\nuget pack ..\SpecEasy\SpecEasy.csproj -Prop Configuration="Release 4.5.1" -Verbosity detailed

--- a/readme.md
+++ b/readme.md
@@ -389,6 +389,7 @@ You can combine SpecEasy with any assertion framework; the core SpecEasy assembl
 SpecEasy is released under the [MIT license](https://raw.github.com/trackabout/speceasy/master/LICENSE).
 
 [NuGet]: https://www.nuget.org/packages/SpecEasy
+[NUnit]: https://www.nuget.org/packages/NUnit/
 [RhinoMocks]: https://www.nuget.org/packages/RhinoMocks/
 [Should]: https://github.com/erichexter/Should
 [Shouldly]: http://shouldly.github.io/


### PR DESCRIPTION
Add support for .NET 4.5 so that we make use of the SpecEasy v2.0 improvements witout upgrading our projects and application environments to .NET 4.5.1.

The changes of note in this pull request are:
1. Created new solution and project build configurations to target .NET 4.5. The new configuration names are 'Debug 4.5' and 'Release 4.5'.
2. Change the name of the existing Debug and Release configurations to "Debug 4.5.1" and "Release 4.5.1", respectively. This was not necessary but I felt that it might be helpful to explicitly identify the target. I did not change the output path for these existing configurations in order to avoid the possibility of causing a problem if folks have references to those folders. They are still `bin/Debug` and `bin/Release`.
3. Updated the NuGet spec file, SpecEasy.nuspec, to create a new lib folder containing the .NET 4.5 version of the assembly, which will be referenced when SpecEasy is added to a project that targets .NET 4.5.
4. Created a batch file named `build.nuget.bat` that can be used to build both the 4.5 and 4.5.1 configurations and then generate the Nuget package with both versions.
5. Updated the version to 2.1.0.0. @mmertsock and I felt that this was an appropriate version given the somewhat recent method under test exception handling changes.
6. Updated NUnit to v2.6.4.
7. Updated Dapper dot net to v1.3.8.

**Note:** I found out last week that we have already upgraded our app environments to 4.5.1. We have not yet retargeted our projects to 4.5.1 but could do so now. So, in the end, this wasn't necessary for us but I had already completed it so I thought I might as well push it in case it helps someone else. Plus, I think the changes related to supporting multiple framework releases in one Nuget package could prove helpful later.
### Unrelated Change to Resolve Compiler Issue

There is an unrelated [change](https://github.com/ronrat/speceasy/commit/06af3773249076328f1ea5a1257d03cacd5eb4e2) in this pull request that I want to call attention to. While testing the 2.1 release using an existing project, I encountered the following compiler error.

```
CSC : error CS0010: Unexpected fatal error -- 'Not enough storage is available to process this command. '
```

Compiling from Visual Studio and watching the compiler task in Windows Explorer showed that its memory usage rose to 4 GB before failing with this error. When compiling from the command line, the memory usage rose to over 8 GB but the compile never completed. Through trial and error, I eventually tracked it to a particular test fixture that contains a Given.Verify nesting that is 15 levels deep. By decreasing the levels of nesting I was able to get the project to compile but the memory usage was still excessive - about 1.5 GB. Before referencing SpecEasy 2.1, the compiler would use around 200 MB, at most. So, I kept digging and eventually found that it was being caused by the new `void Verify(Func<Task> addSpecs)` method in `IContext`. Interestingly, even R# would go into an endless loop when attempting to find uses of that method. It turns out that nothing in the SpecEasy project was using that method and, when I remove it, the compiler issue disappeared. I don't understand why but I have a suspicion it has something to do with the compiler attempting to differentiate between that method and the overload that takes an `Action`.

Would someone that has fixtures testing async methods please compile and run with these changes to make sure I haven't broken anything?
