### PR TITLE
Support for testing classes with non-public ctors

### DIFF
--- a/SpecEasy.ExternalLib/IMagicNumberLookup.cs
+++ b/SpecEasy.ExternalLib/IMagicNumberLookup.cs
@@ -1,0 +1,9 @@
+﻿using System;
+
+namespace SpecEasy.ExternalLib
+{
+    internal interface IMagicNumberLookup
+    {
+        int Lookup(int input);
+    }
+}

--- a/SpecEasy.ExternalLib/MagicNumberAdder.cs
+++ b/SpecEasy.ExternalLib/MagicNumberAdder.cs
@@ -1,0 +1,20 @@
+﻿
+namespace SpecEasy.ExternalLib
+{
+    internal class MagicNumberAdder
+    {
+        private readonly IMagicNumberLookup magicNumberLookup;
+
+        internal MagicNumberAdder(IMagicNumberLookup magicNumberLookup)
+        {
+            this.magicNumberLookup = magicNumberLookup;
+        }
+
+        internal int AddNumbers(int a, int b)
+        {
+            var actualA = magicNumberLookup.Lookup(a);
+            var actualB = magicNumberLookup.Lookup(b);
+            return actualA + actualB;
+        }
+    }
+}

--- a/SpecEasy.ExternalLib/Properties/AssemblyInfo.cs
+++ b/SpecEasy.ExternalLib/Properties/AssemblyInfo.cs
@@ -1,0 +1,39 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following 
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("SpecEasy.ExternalLib")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("SpecEasy.ExternalLib")]
+[assembly: AssemblyCopyright("Copyright ©  2015")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible 
+// to COM components.  If you need to access a type in this assembly from 
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("da1e399d-5136-470e-b780-154bf8ddc5ee")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version 
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers 
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]
+[assembly: InternalsVisibleTo("SpecEasy.Specs")]
+[assembly: InternalsVisibleTo("DynamicProxyGenAssembly2")]
+

--- a/SpecEasy.ExternalLib/SpecEasy.ExternalLib.csproj
+++ b/SpecEasy.ExternalLib/SpecEasy.ExternalLib.csproj
@@ -1,0 +1,58 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{DA1E399D-5136-470E-B780-154BF8DDC5EE}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>SpecEasy.ExternalLib</RootNamespace>
+    <AssemblyName>SpecEasy.ExternalLib</AssemblyName>
+    <TargetFrameworkVersion>v4.5.1</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <TargetFrameworkProfile />
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug 4.5.1|AnyCPU'">
+    <DebugSymbols>true</DebugSymbols>
+    <OutputPath>bin\Debug 4.5.1\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <DebugType>full</DebugType>
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <ErrorReport>prompt</ErrorReport>
+    <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug 4.5|AnyCPU'">
+    <DebugSymbols>true</DebugSymbols>
+    <OutputPath>bin\Debug 4.5\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <DebugType>full</DebugType>
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <ErrorReport>prompt</ErrorReport>
+    <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release 4.5|AnyCPU'">
+    <OutputPath>bin\Release 4.5\</OutputPath>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release 4.5.1|AnyCPU'">
+    <OutputPath>bin\Release 4.5.1\</OutputPath>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="Microsoft.CSharp" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="IMagicNumberLookup.cs" />
+    <Compile Include="MagicNumberAdder.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>

--- a/SpecEasy.Specs/ExternalSpec/MagicNumberAdderSpec.cs
+++ b/SpecEasy.Specs/ExternalSpec/MagicNumberAdderSpec.cs
@@ -1,0 +1,24 @@
+﻿using SpecEasy.ExternalLib;
+using Rhino.Mocks;
+using Should;
+
+namespace SpecEasy.Specs.ExternalSpec
+{
+    internal class MagicNumberAdderSpec : Spec<MagicNumberAdder>
+    {
+        public void Add()
+        {
+            int result = -1;
+            int a = 0;
+            int b = 0;
+
+            When("adding two numbers together", () => result = SUT.AddNumbers(a, b));
+
+            Given("the first number is 3", () => a = 3).Verify(() =>
+                Given("the magic numbe associated with 3 is 7", () => Get<IMagicNumberLookup>().Stub(l => l.Lookup(3)).Return(7)).Verify(() =>
+                    Given("the second number is 2", () => b = 2).Verify(() =>
+                        Given("the magic number associated with 2 is 3", () => Get<IMagicNumberLookup>().Stub(l => l.Lookup(2)).Return(3)).Verify(() =>
+                            Then("the result should be 10", () => result.ShouldEqual(10))))));
+        }
+    }
+}

--- a/SpecEasy.Specs/ExternalSpec/MagicNumberAdderSpec.cs
+++ b/SpecEasy.Specs/ExternalSpec/MagicNumberAdderSpec.cs
@@ -15,7 +15,7 @@ namespace SpecEasy.Specs.ExternalSpec
             When("adding two numbers together", () => result = SUT.AddNumbers(a, b));
 
             Given("the first number is 3", () => a = 3).Verify(() =>
-                Given("the magic numbe associated with 3 is 7", () => Get<IMagicNumberLookup>().Stub(l => l.Lookup(3)).Return(7)).Verify(() =>
+                Given("the magic number associated with 3 is 7", () => Get<IMagicNumberLookup>().Stub(l => l.Lookup(3)).Return(7)).Verify(() =>
                     Given("the second number is 2", () => b = 2).Verify(() =>
                         Given("the magic number associated with 2 is 3", () => Get<IMagicNumberLookup>().Stub(l => l.Lookup(2)).Return(3)).Verify(() =>
                             Then("the result should be 10", () => result.ShouldEqual(10))))));

--- a/SpecEasy.Specs/SpecEasy.Specs.csproj
+++ b/SpecEasy.Specs/SpecEasy.Specs.csproj
@@ -76,17 +76,17 @@
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\packages\Dapper.1.38\lib\net45\Dapper.dll</HintPath>
     </Reference>
-    <Reference Include="nunit.core, Version=2.6.3.13283, Culture=neutral, PublicKeyToken=96d09a1eb7f44a77, processorArchitecture=MSIL">
+    <Reference Include="nunit.core, Version=2.6.4.14350, Culture=neutral, PublicKeyToken=96d09a1eb7f44a77, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\packages\NUnit.Runners.2.6.4\tools\lib\nunit.core.dll</HintPath>
     </Reference>
-    <Reference Include="nunit.core.interfaces, Version=2.6.3.13283, Culture=neutral, PublicKeyToken=96d09a1eb7f44a77, processorArchitecture=MSIL">
+    <Reference Include="nunit.core.interfaces, Version=2.6.4.14350, Culture=neutral, PublicKeyToken=96d09a1eb7f44a77, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\packages\NUnit.Runners.2.6.4\tools\lib\nunit.core.interfaces.dll</HintPath>
     </Reference>
     <Reference Include="nunit.framework, Version=2.6.4.14350, Culture=neutral, PublicKeyToken=96d09a1eb7f44a77, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
       <HintPath>..\packages\NUnit.2.6.4\lib\nunit.framework.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="Rhino.Mocks, Version=3.6.0.0, Culture=neutral, PublicKeyToken=0b3305902db7183f, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
@@ -121,12 +121,17 @@
     <Compile Include="ExceptionReporting\ExceptionReporting.cs" />
     <Compile Include="ExceptionReporting\NUnitBrokenClassTests.cs" />
     <Compile Include="ExceptionReporting\TestResultExtensions.cs" />
+    <Compile Include="ExternalSpec\NumberAdderSpec.cs" />
     <Compile Include="FizzBuzz\FizzBuzzSpecs.cs" />
     <Compile Include="GenericSpec\AutoMockSpec.cs" />
     <Compile Include="GivenCount\GivenCountSpecs.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
+    <ProjectReference Include="..\SpecEasy.ExternalLib\SpecEasy.ExternalLib.csproj">
+      <Project>{da1e399d-5136-470e-b780-154bf8ddc5ee}</Project>
+      <Name>SpecEasy.ExternalLib</Name>
+    </ProjectReference>
     <ProjectReference Include="..\SpecEasy\SpecEasy.csproj">
       <Project>{d15653fb-10a8-4abb-bacd-a1694fc3251c}</Project>
       <Name>SpecEasy</Name>
@@ -140,6 +145,7 @@
   </ItemGroup>
   <ItemGroup>
     <Service Include="{508349B6-6B84-4DF5-91F0-309BEEBAD82D}" />
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
   </ItemGroup>
   <ItemGroup>
     <BootstrapperPackage Include=".NETFramework,Version=v4.0">

--- a/SpecEasy.Specs/SpecEasy.Specs.csproj
+++ b/SpecEasy.Specs/SpecEasy.Specs.csproj
@@ -121,11 +121,19 @@
     <Compile Include="ExceptionReporting\ExceptionReporting.cs" />
     <Compile Include="ExceptionReporting\NUnitBrokenClassTests.cs" />
     <Compile Include="ExceptionReporting\TestResultExtensions.cs" />
-    <Compile Include="ExternalSpec\NumberAdderSpec.cs" />
     <Compile Include="FizzBuzz\FizzBuzzSpecs.cs" />
     <Compile Include="GenericSpec\AutoMockSpec.cs" />
     <Compile Include="GivenCount\GivenCountSpecs.cs" />
+    <Compile Include="ExternalSpec\MagicNumberAdderSpec.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="TinyIoC\PublicAndInternalCtors.cs" />
+    <Compile Include="TinyIoC\PublicAndPrivateCtors.cs" />
+    <Compile Include="TinyIoC\SinglePublicCtor.cs" />
+    <Compile Include="TinyIoC\TinyIoCPublicAndInternalCtorsSpec.cs" />
+    <Compile Include="TinyIoC\TinyIoCPublicAndPrivateCtorsSpec.cs" />
+    <Compile Include="TinyIoC\TinyIoCSinglePublicCtorSpec.cs" />
+    <Compile Include="TinyIoC\TinyIoCTwoPublicCtorsSpec.cs" />
+    <Compile Include="TinyIoC\TwoPublicCtors.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\SpecEasy.ExternalLib\SpecEasy.ExternalLib.csproj">

--- a/SpecEasy.Specs/SpecEasy.Specs.csproj
+++ b/SpecEasy.Specs/SpecEasy.Specs.csproj
@@ -128,9 +128,11 @@
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="TinyIoC\PublicAndInternalCtors.cs" />
     <Compile Include="TinyIoC\PublicAndPrivateCtors.cs" />
+    <Compile Include="TinyIoC\SinglePrivateCtor.cs" />
     <Compile Include="TinyIoC\SinglePublicCtor.cs" />
     <Compile Include="TinyIoC\TinyIoCPublicAndInternalCtorsSpec.cs" />
     <Compile Include="TinyIoC\TinyIoCPublicAndPrivateCtorsSpec.cs" />
+    <Compile Include="TinyIoC\TinyIoCSinglePrivateCtorSpec.cs" />
     <Compile Include="TinyIoC\TinyIoCSinglePublicCtorSpec.cs" />
     <Compile Include="TinyIoC\TinyIoCTwoPublicCtorsSpec.cs" />
     <Compile Include="TinyIoC\TwoPublicCtors.cs" />

--- a/SpecEasy.Specs/TinyIoC/PublicAndInternalCtors.cs
+++ b/SpecEasy.Specs/TinyIoC/PublicAndInternalCtors.cs
@@ -1,0 +1,28 @@
+namespace SpecEasy.Specs.TinyIoC
+{
+    internal class PublicAndInternalCtors
+    {
+        public object Arg1
+        {
+            get;
+            private set;
+        }
+
+        public object Arg2
+        {
+            get;
+            private set;
+        }
+
+        internal PublicAndInternalCtors(object arg1)
+        {
+            Arg1 = arg1;
+        }
+
+        public PublicAndInternalCtors(object arg1, object arg2)
+        {
+            Arg1 = arg1;
+            Arg2 = arg2;
+        }
+    }
+}

--- a/SpecEasy.Specs/TinyIoC/PublicAndPrivateCtors.cs
+++ b/SpecEasy.Specs/TinyIoC/PublicAndPrivateCtors.cs
@@ -1,0 +1,28 @@
+﻿namespace SpecEasy.Specs.TinyIoC
+{
+    internal class PublicAndPrivateCtors
+    {
+        public object Arg1
+        {
+            get;
+            private set;
+        }
+
+        public object Arg2
+        {
+            get;
+            private set;
+        }
+
+        private PublicAndPrivateCtors(object arg1)
+        {
+            Arg1 = arg1;
+        }
+
+        public PublicAndPrivateCtors(object arg1, object arg2)
+        {
+            Arg1 = arg1;
+            Arg2 = arg2;
+        }
+    }
+}

--- a/SpecEasy.Specs/TinyIoC/SinglePrivateCtor.cs
+++ b/SpecEasy.Specs/TinyIoC/SinglePrivateCtor.cs
@@ -1,0 +1,16 @@
+namespace SpecEasy.Specs.TinyIoC
+{
+    internal class SinglePrivateCtor
+    {
+        public object Arg1
+        {
+            get;
+            private set;
+        }
+
+        private SinglePrivateCtor(object arg1)
+        {
+            Arg1 = arg1;
+        }
+    }
+}

--- a/SpecEasy.Specs/TinyIoC/SinglePublicCtor.cs
+++ b/SpecEasy.Specs/TinyIoC/SinglePublicCtor.cs
@@ -1,0 +1,16 @@
+namespace SpecEasy.Specs.TinyIoC
+{
+    internal class SinglePublicCtor
+    {
+        public object Arg1
+        {
+            get;
+            private set;
+        }
+
+        public SinglePublicCtor(object arg1)
+        {
+            Arg1 = arg1;
+        }
+    }
+}

--- a/SpecEasy.Specs/TinyIoC/TinyIoCPublicAndInternalCtorsSpec.cs
+++ b/SpecEasy.Specs/TinyIoC/TinyIoCPublicAndInternalCtorsSpec.cs
@@ -1,0 +1,19 @@
+using NUnit.Framework;
+
+namespace SpecEasy.Specs.TinyIoC
+{
+    internal class TinyIoCPublicAndInternalCtorsSpec : Spec<PublicAndInternalCtors>
+    {
+        public void ConstructorSelection()
+        {
+            When("constructing the SUT instance", () => EnsureSUT());
+
+            Given("the type being constructed has both public and internal constructors and the internal constructor has the fewest parameters").Verify(() =>
+                Then("the public ctor should be used to construct the SUT instance", () =>
+                {
+                    Assert.IsNotNull(SUT.Arg1);
+                    Assert.IsNotNull(SUT.Arg2);
+                }));
+        }   
+    }
+}

--- a/SpecEasy.Specs/TinyIoC/TinyIoCPublicAndPrivateCtorsSpec.cs
+++ b/SpecEasy.Specs/TinyIoC/TinyIoCPublicAndPrivateCtorsSpec.cs
@@ -1,0 +1,19 @@
+using NUnit.Framework;
+
+namespace SpecEasy.Specs.TinyIoC
+{
+    internal class TinyIoCPublicAndPrivateCtorsSpec : Spec<PublicAndPrivateCtors>
+    {
+        public void ConstructorSelection()
+        {
+            When("construcing the SUT instance", () => EnsureSUT());
+
+            Given("the type being constructed has both a public and private ctor and the private ctor is the one with the fewest parameters").Verify(() =>
+                Then("the public ctor should be used to construct the SUT instance", () =>
+                {
+                    Assert.IsNotNull(SUT.Arg1);
+                    Assert.IsNotNull(SUT.Arg2);
+                }));
+        }
+    }
+}

--- a/SpecEasy.Specs/TinyIoC/TinyIoCSinglePrivateCtorSpec.cs
+++ b/SpecEasy.Specs/TinyIoC/TinyIoCSinglePrivateCtorSpec.cs
@@ -1,0 +1,15 @@
+using TinyIoC;
+
+namespace SpecEasy.Specs.TinyIoC
+{
+    internal class TinyIoCSinglePrivateCtorSpec : Spec<SinglePrivateCtor>
+    {
+        public void ConstructorSelection()
+        {
+            When("constructing the SUT instance", () => EnsureSUT());
+
+            Given("the type being constructed has a single private constructor").Verify(() =>
+                Then("an exception should be thrown because we will not use private ctors to build the SUT instance", () => AssertWasThrown<TinyIoCResolutionException>()));
+        }
+    }
+}

--- a/SpecEasy.Specs/TinyIoC/TinyIoCSinglePublicCtorSpec.cs
+++ b/SpecEasy.Specs/TinyIoC/TinyIoCSinglePublicCtorSpec.cs
@@ -1,0 +1,15 @@
+using NUnit.Framework;
+
+namespace SpecEasy.Specs.TinyIoC
+{
+    internal class TinyIoCSinglePublicCtorSpec : Spec<SinglePublicCtor>
+    {
+        public void ConstructorSelection()
+        {
+            When("constructing the SUT instance", () => EnsureSUT());
+
+            Given("the target type has a single public ctor").Verify(() =>
+                Then("the single public ctor should be used to construct the SUT", () => Assert.IsNotNull(SUT.Arg1)));
+        }
+    }
+}

--- a/SpecEasy.Specs/TinyIoC/TinyIoCTwoPublicCtorsSpec.cs
+++ b/SpecEasy.Specs/TinyIoC/TinyIoCTwoPublicCtorsSpec.cs
@@ -1,0 +1,19 @@
+using NUnit.Framework;
+
+namespace SpecEasy.Specs.TinyIoC
+{
+    internal class TinyIoCTwoPublicCtorsSpec : Spec<TwoPublicCtors>
+    {
+        public void ConstructorSelection()
+        {
+            When("constructing the SUT instance", () => EnsureSUT());
+
+            Given("the target type has two public ctors with different numbers of parameters").Verify(() =>
+                Then("the ctor with the fewest parameters should be used to construct the SUT", () =>
+                {
+                    Assert.IsNotNull(SUT.Arg1);
+                    Assert.IsNull(SUT.Arg2);
+                }));
+        }
+    }
+}

--- a/SpecEasy.Specs/TinyIoC/TwoPublicCtors.cs
+++ b/SpecEasy.Specs/TinyIoC/TwoPublicCtors.cs
@@ -1,0 +1,28 @@
+namespace SpecEasy.Specs.TinyIoC
+{
+    internal class TwoPublicCtors
+    {
+        public object Arg1
+        {
+            get;
+            private set;
+        }
+
+        public object Arg2
+        {
+            get;
+            private set;
+        }
+
+        public TwoPublicCtors(object arg1)
+        {
+            Arg1 = arg1;
+        }
+
+        public TwoPublicCtors(object arg1, object arg2)
+        {
+            Arg1 = arg1;
+            Arg2 = arg2;
+        }
+    }
+}

--- a/SpecEasy.Specs/packages.config
+++ b/SpecEasy.Specs/packages.config
@@ -1,7 +1,8 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Dapper" version="1.38" targetFramework="net451" />
-  <package id="NUnit" version="2.6.4" targetFramework="net451" />
-  <package id="RhinoMocks" version="3.6.1" targetFramework="net40" />
-  <package id="Should" version="1.1.20" targetFramework="net451" />
+  <package id="Dapper" version="1.38" targetFramework="net451" userInstalled="true" />
+  <package id="NUnit" version="2.6.4" targetFramework="net451" userInstalled="true" />
+  <package id="NUnit.Runners" version="2.6.4" targetFramework="net451" userInstalled="true" />
+  <package id="RhinoMocks" version="3.6.1" targetFramework="net4" userInstalled="true" />
+  <package id="Should" version="1.1.20" targetFramework="net451" userInstalled="true" />
 </packages>

--- a/SpecEasy.sln
+++ b/SpecEasy.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 2013
-VisualStudioVersion = 12.0.31101.0
+# Visual Studio 14
+VisualStudioVersion = 14.0.22823.1
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SpecEasy", "SpecEasy\SpecEasy.csproj", "{D15653FB-10A8-4ABB-BACD-A1694FC3251C}"
 EndProject
@@ -16,6 +16,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Build", "Build", "{56D50E15
 	EndProjectSection
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SpecEasy.Specs", "SpecEasy.Specs\SpecEasy.Specs.csproj", "{101D8D3F-3FAD-4E2A-B483-32338C6E7EAB}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SpecEasy.ExternalLib", "SpecEasy.ExternalLib\SpecEasy.ExternalLib.csproj", "{DA1E399D-5136-470E-B780-154BF8DDC5EE}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution

--- a/SpecEasy.sln
+++ b/SpecEasy.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 14
-VisualStudioVersion = 14.0.22823.1
+VisualStudioVersion = 14.0.23107.0
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SpecEasy", "SpecEasy\SpecEasy.csproj", "{D15653FB-10A8-4ABB-BACD-A1694FC3251C}"
 EndProject
@@ -43,6 +43,14 @@ Global
 		{101D8D3F-3FAD-4E2A-B483-32338C6E7EAB}.Release 4.5.1|Any CPU.Build.0 = Release 4.5.1|Any CPU
 		{101D8D3F-3FAD-4E2A-B483-32338C6E7EAB}.Release 4.5|Any CPU.ActiveCfg = Release 4.5|Any CPU
 		{101D8D3F-3FAD-4E2A-B483-32338C6E7EAB}.Release 4.5|Any CPU.Build.0 = Release 4.5|Any CPU
+		{DA1E399D-5136-470E-B780-154BF8DDC5EE}.Debug 4.5.1|Any CPU.ActiveCfg = Debug 4.5.1|Any CPU
+		{DA1E399D-5136-470E-B780-154BF8DDC5EE}.Debug 4.5.1|Any CPU.Build.0 = Debug 4.5.1|Any CPU
+		{DA1E399D-5136-470E-B780-154BF8DDC5EE}.Debug 4.5|Any CPU.ActiveCfg = Debug 4.5|Any CPU
+		{DA1E399D-5136-470E-B780-154BF8DDC5EE}.Debug 4.5|Any CPU.Build.0 = Debug 4.5|Any CPU
+		{DA1E399D-5136-470E-B780-154BF8DDC5EE}.Release 4.5.1|Any CPU.ActiveCfg = Release 4.5.1|Any CPU
+		{DA1E399D-5136-470E-B780-154BF8DDC5EE}.Release 4.5.1|Any CPU.Build.0 = Release 4.5.1|Any CPU
+		{DA1E399D-5136-470E-B780-154BF8DDC5EE}.Release 4.5|Any CPU.ActiveCfg = Release 4.5|Any CPU
+		{DA1E399D-5136-470E-B780-154BF8DDC5EE}.Release 4.5|Any CPU.Build.0 = Release 4.5|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/SpecEasy/GenericSpec.cs
+++ b/SpecEasy/GenericSpec.cs
@@ -81,6 +81,11 @@ namespace SpecEasy
             MockingContainer.Register(typeof(TUnit)).AsSingleton();
         }
 
+        protected void EnsureSUT()
+        {
+            Get<TUnit>();
+        }
+
         protected TUnit SUT
         {
             get { return Get<TUnit>(); }

--- a/SpecEasy/Properties/AssemblyInfo.cs
+++ b/SpecEasy/Properties/AssemblyInfo.cs
@@ -1,4 +1,5 @@
 ﻿using System.Reflection;
+using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
 // General Information about an assembly is controlled through the following
@@ -31,3 +32,7 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Revision and Build Numbers
 // by using the '*' as shown below:
 [assembly: AssemblyVersion("2.1.0.0")]
+
+#if DEBUG
+[assembly: InternalsVisibleTo("SpecEasy.Specs")]
+#endif

--- a/SpecEasy/SpecEasy.csproj
+++ b/SpecEasy/SpecEasy.csproj
@@ -120,6 +120,9 @@
       <Install>true</Install>
     </BootstrapperPackage>
   </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <ProjectExtensions>
     <VisualStudio>

--- a/SpecEasy/TinyIoC.cs
+++ b/SpecEasy/TinyIoC.cs
@@ -811,9 +811,9 @@ namespace TinyIoC
 
     internal sealed partial class TinyIoCContainer : IDisposable
     {
-        private const int PublicScopeSortValue = 1;
-        private const int InternalScopeSortValue = 2;
-        private const int PrivateAndProtectedScopeSortValue = 3;
+        private const int PUBLIC_SCOPE_SORT_VALUE = 1;
+        private const int INTERNAL_SCOPE_SORT_VALUE = 2;
+        private const int PRIVATE_AND_PROTECTED_SCOPE_SORT_VALUE = 3;
 
         #region Fake NETFX_CORE Classes
 #if NETFX_CORE
@@ -3642,15 +3642,15 @@ namespace TinyIoC
         {
             if (ctor.IsPublic)
             {
-                return PublicScopeSortValue;
+                return PUBLIC_SCOPE_SORT_VALUE;
             }
 
             if (ctor.IsAssembly)
             {
-                return InternalScopeSortValue;
+                return INTERNAL_SCOPE_SORT_VALUE;
             }
 
-            return PrivateAndProtectedScopeSortValue;
+            return PRIVATE_AND_PROTECTED_SCOPE_SORT_VALUE;
         }
 
         private object ConstructType(Type requestedType, Type implementationType, ResolveOptions options)

--- a/SpecEasy/TinyIoC.cs
+++ b/SpecEasy/TinyIoC.cs
@@ -3619,12 +3619,8 @@ namespace TinyIoC
 
         private IEnumerable<ConstructorInfo> GetTypeConstructors(Type type)
         {
-//#if NETFX_CORE
-//			return type.GetTypeInfo().DeclaredConstructors.OrderByDescending(ctor => ctor.GetParameters().Count());
-//#else
-            return type.GetConstructors().OrderByDescending(ctor => ctor.GetParameters().Count());
-//#endif
-        }
+			return type.GetTypeInfo().DeclaredConstructors.OrderByDescending(ctor => ctor.GetParameters().Count());
+        } 
 
         private object ConstructType(Type requestedType, Type implementationType, ResolveOptions options)
         {

--- a/SpecEasy/TinyIoC.cs
+++ b/SpecEasy/TinyIoC.cs
@@ -811,6 +811,10 @@ namespace TinyIoC
 
     internal sealed partial class TinyIoCContainer : IDisposable
     {
+        private const int PublicScopeSortValue = 1;
+        private const int InternalScopeSortValue = 2;
+        private const int PrivateAndProtectedScopeSortValue = 3;
+
         #region Fake NETFX_CORE Classes
 #if NETFX_CORE
         private sealed class MethodAccessException : Exception
@@ -3638,15 +3642,15 @@ namespace TinyIoC
         {
             if (ctor.IsPublic)
             {
-                return 1;
+                return PublicScopeSortValue;
             }
 
             if (ctor.IsAssembly)
             {
-                return 2;
+                return InternalScopeSortValue;
             }
 
-            return 3;
+            return PrivateAndProtectedScopeSortValue;
         }
 
         private object ConstructType(Type requestedType, Type implementationType, ResolveOptions options)


### PR DESCRIPTION
Howdy SpecEasy-ians.

We use a fair bit of internal classes in our projects and often want to have those classes use internal constructors. We've been having issues with the TinyIoC implementation we have embedded into SpecyEasy resolving and creating those SUT instances if the target type has an internal ctor. The issue was that TinyIoC wasn't finding the internal ctors via the reflection calls it was making and therefore just blew  up while trying to build the SUT instance.

I created an extra class lib in the solution (with the Dumbest Code Ever(tm) in it) with 'InternalsVisibleTo' assembly meta data to repro the issue. As it turns out, the fix appears to be pretty easy. There was some commented out code in the TinyIoC file that was using the newer 'DeclaredConstructors' property that was made available in .NET 4.5, and that property returns ''all'' constructors (not just public ones).  If I were building a general purpose IoC container I'd say that behavior is maybe not always desired, but for the purposes of SpecEasy I'd say that we probably do want to allow for constructing SUT instances using non-public ctors if possible.

A couple of other notes:
- This change would mean that TinyIoC could resolve SUTs that have private constructors. I'm not sure how I feel about that exactly... I'm open to thoughts or concerns though.
- There was some weirdness with the nUnit package when I first cloned the repo and tried to build it, I was missing refs to nunit.core and nunit.core.interfaces. The .csproj file wanted them to be under /packages/nunit.test.runner (or something like that), but our packages config didn't include that page. I went ahead and included it, and that made things work, but I noticed also bumped the version of those assemblies from 2.6.3.<something> to 2.6.4.<something>. This is only for the SpecEasy.Specs assembly and won't actually impact the Speceasy.dll that we're shipping, so it shouldn't matter but I wanted to mention it.
- I made this change with CTP of Visual Studio 2015, and it tagged the .sln file accordingly. Not sure that we care.
- The SpecEasy.Specs project got a new "service include={guid}" node added that apparently is harmless and just used by the built-in VS test runner to know that a certain project contains unit tests.

Let me know what you think!
