### PR TITLE
Adding test setup class that can override how a SUT is built.

### DIFF
--- a/SpecEasy.Specs/BeforeEachAndAfterEachExampleSpecs/SutSetterAndConstructSutSpec.cs
+++ b/SpecEasy.Specs/BeforeEachAndAfterEachExampleSpecs/SutSetterAndConstructSutSpec.cs
@@ -1,0 +1,25 @@
+﻿using Should;
+
+namespace SpecEasy.Specs.BeforeEachAndAfterEachExampleSpecs
+{
+    class SutSetterAndConstructSutSpec : Spec<SutWithValueTypeDependency>
+    {
+        protected override SutWithValueTypeDependency ConstructSUT()
+        {
+            return new SutWithValueTypeDependency(456);
+        }
+
+        public void Run()
+        {
+            var value = 0;
+
+            When("getting value from SUT", () => value = SUT.Value);
+
+            Given("SUT has not been explicitly set").Verify(() =>
+                Then("it should get the value used in ConstructSUT", () => value.ShouldEqual(456)));
+
+            Given("SUT has been explicitly set", () => SUT = new SutWithValueTypeDependency(123)).Verify(() =>
+                Then("it should get the value provided when the SUT was explicitly set", () => value.ShouldEqual(123)));
+        }
+    }
+}

--- a/SpecEasy.Specs/BeforeEachAndAfterEachExampleSpecs/SutWithValueTypeDependency.cs
+++ b/SpecEasy.Specs/BeforeEachAndAfterEachExampleSpecs/SutWithValueTypeDependency.cs
@@ -1,0 +1,12 @@
+﻿namespace SpecEasy.Specs.BeforeEachAndAfterEachExampleSpecs
+{
+    internal class SutWithValueTypeDependency
+    {
+        public int Value { get; private set; }
+
+        public SutWithValueTypeDependency(int value)
+        {
+            Value = value;
+        }
+    }
+}

--- a/SpecEasy.Specs/GenericSpec/AutoMockSpec.cs
+++ b/SpecEasy.Specs/GenericSpec/AutoMockSpec.cs
@@ -5,6 +5,9 @@ namespace SpecEasy.Specs.GenericSpec
 {
     public class AutoMockSpec : Spec<Mockable>
     {
+        private const string StubbedDepValue = "stub-value-1";
+        private const string ManuallyRegisteredDepValue = "dep-1-impl";
+
         public void Run()
         {
             When("testing a class with constructor dependencies", () => { });
@@ -15,25 +18,30 @@ namespace SpecEasy.Specs.GenericSpec
                 {
                     var sut1 = SUT;
                     var sut2 = SUT;
+                    var sut3 = Get<Mockable>();
+                    var sut4 = Get<Mockable>();
                     sut1.ShouldBeSameAs(sut2);
+                    sut2.ShouldBeSameAs(sut3);
+                    sut3.ShouldBeSameAs(sut4);
                 });
 
                 Then("it gets a default mock object for dependency 1", () => SUT.Dep1.ShouldNotBeType<Dependency1Impl>());
-                Given("stubbed values for dependencies", () => Get<IDependency1>().Stub(d => d.Value).Return("stub-value-1")).Verify(() =>
+
+                Given("stubbed values for dependencies", () => Get<IDependency1>().Stub(d => d.Value).Return(StubbedDepValue)).Verify(() =>
                     Then("it should produce the same instance of a mock dependency each time it's requested", () =>
                         Get<IDependency1>().ShouldBeSameAs(Get<IDependency1>())).
                     Then("it should get stubbed values from its mocked dependencies", () =>
-                        SUT.Dep1.Value.ShouldEqual("stub-value-1"))
+                        SUT.Dep1.Value.ShouldEqual(StubbedDepValue))
                 );
             });
 
-            Given("a dependency registered by the caller", () => Set<IDependency1>(new Dependency1Impl("dep-1-impl"))).Verify(() =>
+            Given("a dependency registered by the caller", () => Set<IDependency1>(new Dependency1Impl(ManuallyRegisteredDepValue))).Verify(() =>
                 Then("it gets the same object each time a registered class is requested", () =>
                     Get<IDependency1>().ShouldBeSameAs(Get<IDependency1>())).
                 Then("it gets the same object each time an unregistered concrete object is requested", () =>
                     Get<Dependency2Impl>().ShouldBeSameAs(Get<Dependency2Impl>())).
                 Then("it gets the specified object for dependency 1", () =>
-                    SUT.Dep1.Value.ShouldEqual("dep-1-impl")));
+                    SUT.Dep1.Value.ShouldEqual(ManuallyRegisteredDepValue)));
         }
     }
 

--- a/SpecEasy.Specs/GenericSpec/InvalidCreateSUTTests.cs
+++ b/SpecEasy.Specs/GenericSpec/InvalidCreateSUTTests.cs
@@ -1,0 +1,27 @@
+﻿using System.Linq;
+using NUnit.Framework;
+using SpecEasy.Specs.GenericSpec.SupportingExamples;
+
+namespace SpecEasy.Specs.GenericSpec
+{
+    [TestFixture]
+    public class InvalidCreateSUTTests
+    {
+        [Test]
+        public void NullReturningInvalidCreateSUTTest()
+        {
+            var result = SpecRunner.Run<NullReturningInvalidCreateSUTSpec>();
+            Assert.Greater(result.FailedTests().Count(), 0);
+            Assert.IsTrue(result.FailedTests().All(ft => ft.Message.StartsWith("System.InvalidOperationException") && ft.Message.Contains("Failed to construct SUT: ConstructSUT returned null")), "At least one failed spec reported an assertion error when it should have reported an exception.");
+        }
+
+        [Test]
+        public void ExceptionThrowingInvalidCreateSUTTest()
+        {
+            var result = SpecRunner.Run<ExceptionThrowingInvalidCreateSUTSpec>();
+            Assert.Greater(result.FailedTests().Count(), 0);
+            Assert.IsTrue(result.FailedTests().All(ft => ft.Message.Equals(
+                $"{ExceptionThrowingInvalidCreateSUTSpec.ConstructSUTThrownException.GetType().FullName} : {ExceptionThrowingInvalidCreateSUTSpec.ConstructSUTThrownException.Message}")));
+        }
+    }
+}

--- a/SpecEasy.Specs/GenericSpec/ManualSUTConstructionSpec.cs
+++ b/SpecEasy.Specs/GenericSpec/ManualSUTConstructionSpec.cs
@@ -1,0 +1,112 @@
+using System;
+using NUnit.Framework;
+using Should;
+
+namespace SpecEasy.Specs.GenericSpec
+{
+    public class ManualSUTConstructionSpec : Spec<Mockable>
+    {
+        private const string ManualConstructedDependencyValue = "Manually Constructed";
+
+        private int constructSUTCallCount;
+        private bool shouldManauallyConstructSUT;
+
+        private Exception constructSUTThrownException;
+        private bool constructSUTReturnsNull;
+
+        public void ManuallyConstructSUT()
+        {
+            When("testing a class that may be constructed manually", () => { });
+
+            Given("the SUT is never accessed").Verify(() =>
+                Then("the method to construct the SUT is never called", () => constructSUTCallCount.ShouldEqual(0)));
+
+            Given("the SUT is constructed automatically", () => shouldManauallyConstructSUT = false).Verify(() =>
+            {
+                Given("the SUT is accessed multiple times", () =>
+                {
+                    EnsureSUT();
+                    EnsureSUT();
+                }).Verify(() =>
+                {
+                    Then("the method to construct the SUT should only be called once", () => constructSUTCallCount.ShouldEqual(1));
+                    Then("the same instance of the SUT is returned every time", () =>
+                    {
+                        var sut1 = SUT;
+                        var sut2 = SUT;
+                        var sut3 = Get<Mockable>();
+                        var sut4 = Get<Mockable>();
+                        sut1.ShouldBeSameAs(sut2);
+                        sut2.ShouldBeSameAs(sut3);
+                        sut3.ShouldBeSameAs(sut4);
+                    });
+                });
+
+                Then("the dependency should be the one automatically constructed", () => SUT.Dep1.ShouldBeSameAs(Get<IDependency1>()));
+            });
+
+            Given("the SUT is constructed manually", () => shouldManauallyConstructSUT = true).Verify(() =>
+            {
+                Given("the SUT is accessed multiple times", () =>
+                {
+                    EnsureSUT();
+                    EnsureSUT();
+                }).Verify(() =>
+                {
+                    Then("the method to construct the SUT should only be called once", () => constructSUTCallCount.ShouldEqual(1));
+                    Then("the same instance of the SUT is returned every time", () =>
+                    {
+                        var sut1 = SUT;
+                        var sut2 = SUT;
+                        var sut3 = Get<Mockable>();
+                        var sut4 = Get<Mockable>();
+                        sut1.ShouldBeSameAs(sut2);
+                        sut2.ShouldBeSameAs(sut3);
+                        sut3.ShouldBeSameAs(sut4);
+                    });
+                });
+
+                Given("the method to construct the SUT throws an exception", () => constructSUTThrownException = new Exception("manually constructing the SUT throws")).Verify(() =>
+                    Given("the SUT is never accessed", () => {}).Verify(() =>
+                        Then("no exception is thrown", () => Assert.Pass())));
+
+                Given("the method to construct the SUT returns null", () => constructSUTReturnsNull = true).Verify(() =>
+                    Given("the SUT is never accessed", () => {}).Verify(() =>
+                        Then("no exception is thrown", () => Assert.Pass())));
+
+                Then("the dependency should be the one manually constructed", () => SUT.Dep1.Value.ShouldEqual(ManualConstructedDependencyValue));
+            });
+        }
+
+        protected override Mockable ConstructSUT()
+        {
+            constructSUTCallCount++;
+
+            if (!shouldManauallyConstructSUT)
+            {
+                return base.ConstructSUT();
+            }
+
+            if (constructSUTThrownException != null)
+            {
+                throw constructSUTThrownException;
+            }
+
+            if (constructSUTReturnsNull)
+            {
+                return null;
+            }
+
+            return new Mockable(new Dependency1Impl(ManualConstructedDependencyValue));
+        }
+
+        protected override void BeforeEachExample()
+        {
+            base.BeforeEachExample();
+
+            constructSUTCallCount = 0;
+            constructSUTThrownException = null;
+            constructSUTReturnsNull = false;
+        }
+    }
+}

--- a/SpecEasy.Specs/GenericSpec/SupportingExamples/ExceptionThrowingInvalidCreateSUTSpec.cs
+++ b/SpecEasy.Specs/GenericSpec/SupportingExamples/ExceptionThrowingInvalidCreateSUTSpec.cs
@@ -1,0 +1,25 @@
+using System;
+using NUnit.Framework;
+
+namespace SpecEasy.Specs.GenericSpec.SupportingExamples
+{
+    [SupportingExample]
+    internal sealed class ExceptionThrowingInvalidCreateSUTSpec : Spec<object>
+    {
+        internal static readonly Exception ConstructSUTThrownException = new Exception("manually constructing the SUT throws");
+
+        public void RunSpec()
+        {
+            When("constructing SUT", () => EnsureSUT());
+
+            Given("the SUT is constructed manually").Verify(() =>
+                Given("the method to construct the SUT throws an exception").Verify(() =>
+                    Then("the exception is thrown", () => Assert.Pass("We don't actually expect to hit this and pass the test; the assertion of the test runner will be that this test fails."))));
+        }
+
+        protected override object ConstructSUT()
+        {
+            throw ConstructSUTThrownException;
+        }
+    }
+}

--- a/SpecEasy.Specs/GenericSpec/SupportingExamples/NullReturningInvalidCreateSUTSpec.cs
+++ b/SpecEasy.Specs/GenericSpec/SupportingExamples/NullReturningInvalidCreateSUTSpec.cs
@@ -1,0 +1,22 @@
+﻿using NUnit.Framework;
+
+namespace SpecEasy.Specs.GenericSpec.SupportingExamples
+{
+    [SupportingExample]
+    internal sealed class NullReturningInvalidCreateSUTSpec : Spec<object>
+    {
+        public void RunSpec()
+        {
+            When("constructing SUT", () => EnsureSUT());
+
+            Given("the SUT is constructed manually").Verify(() =>
+                Given("the method to construct the SUT returns null").Verify(() =>
+                    Then("an appropriate exception is thrown", () => Assert.Pass("We don't actually expect to hit this and pass the test; the assertion of the test runner will be that this test fails."))));
+        }
+
+        protected override object ConstructSUT()
+        {
+            return null;
+        }
+    }
+}

--- a/SpecEasy.Specs/SpecEasy.Specs.csproj
+++ b/SpecEasy.Specs/SpecEasy.Specs.csproj
@@ -126,8 +126,12 @@
     <Compile Include="FizzBuzz\FizzBuzzSpecs.cs" />
     <Compile Include="GenericSpec\AutoMockSpec.cs" />
     <Compile Include="DuplicateDescriptions\DuplicateDescriptionsTests.cs" />
+    <Compile Include="GenericSpec\InvalidCreateSUTTests.cs" />
     <Compile Include="GenericSpec\PartialMockSpec.cs" />
     <Compile Include="GenericSpec\PartialMockWithConstructorParamsSpec.cs" />
+    <Compile Include="GenericSpec\ManualSUTConstructionSpec.cs" />
+    <Compile Include="GenericSpec\SupportingExamples\ExceptionThrowingInvalidCreateSUTSpec.cs" />
+    <Compile Include="GenericSpec\SupportingExamples\NullReturningInvalidCreateSUTSpec.cs" />
     <Compile Include="GivenCount\GivenCountSpecs.cs" />
     <Compile Include="ExternalSpec\MagicNumberAdderSpec.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />

--- a/SpecEasy.Specs/SpecEasy.Specs.csproj
+++ b/SpecEasy.Specs/SpecEasy.Specs.csproj
@@ -116,6 +116,8 @@
     <Compile Include="BeforeEachAndAfterEachExampleSpecs\BeforeEachExampleGetsCalledSpec.cs" />
     <Compile Include="BeforeEachAndAfterEachExampleSpecs\GetSetInBeforeEachExampleSpec.cs" />
     <Compile Include="BeforeEachAndAfterEachExampleSpecs\SutInBeforeEachExampleSpec.cs" />
+    <Compile Include="BeforeEachAndAfterEachExampleSpecs\SutSetterAndConstructSutSpec.cs" />
+    <Compile Include="BeforeEachAndAfterEachExampleSpecs\SutWithValueTypeDependency.cs" />
     <Compile Include="DatabaseIntegration\DatabaseIntegrationSetup.cs" />
     <Compile Include="DuplicateDescriptions\SupportingExamples\DuplicateDescriptionsSpec.cs" />
     <Compile Include="ExceptionAssertions\ExceptionAssertionsSpec.cs" />

--- a/SpecEasy/GenericSpec.cs
+++ b/SpecEasy/GenericSpec.cs
@@ -139,7 +139,12 @@ namespace SpecEasy
         protected TUnit SUT
         {
             get { return GetSUTInstance(); }
-            set { Set(value); }
+            set
+            {
+                constructedSUTInstance = value;
+                Set(value);
+                alreadyConstructedSUT = true;
+            }
         }
     }
 }


### PR DESCRIPTION
This may still need some work, but here's an initial implementation for an idea I've been kicking around.

The idea here is to provide a way to control how the SUT is built by providing a Func<TUnit> that can be used to build one manually. The lifecycle of how an SUT is managed doesn't change, this just short-circuits using the auto mocking container and will invoke the provided function instead if provided.

This is how you use it:

``` c#
public void RunTests()
{
  When("The SUT does something intesresting", () => SUT.DoSomethingInteresting())
  .BuildSUTUsing(() => new SUTImplementation(new Dependency1()));

  //Givens and Thens go here
}
```

Thoughts?

@rockhymas @Fammy @ronrat @mmertsock ?
