### PR TITLE
Prep for v2.1 release.

### DIFF
--- a/SpecEasy.ExternalLib/SpecEasy.ExternalLib.csproj
+++ b/SpecEasy.ExternalLib/SpecEasy.ExternalLib.csproj
@@ -2,7 +2,7 @@
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
-    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug 4.5.1</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
     <ProjectGuid>{DA1E399D-5136-470E-B780-154BF8DDC5EE}</ProjectGuid>
     <OutputType>Library</OutputType>
@@ -14,8 +14,9 @@
     <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug 4.5.1|AnyCPU'">
+    <TargetFrameworkVersion>v4.5.1</TargetFrameworkVersion>
     <DebugSymbols>true</DebugSymbols>
-    <OutputPath>bin\Debug 4.5.1\</OutputPath>
+    <OutputPath>bin\Debug\</OutputPath>
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <DebugType>full</DebugType>
     <PlatformTarget>AnyCPU</PlatformTarget>
@@ -23,8 +24,9 @@
     <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug 4.5|AnyCPU'">
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <DebugSymbols>true</DebugSymbols>
-    <OutputPath>bin\Debug 4.5\</OutputPath>
+    <OutputPath>bin\Debug45\</OutputPath>
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <DebugType>full</DebugType>
     <PlatformTarget>AnyCPU</PlatformTarget>
@@ -32,10 +34,12 @@
     <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release 4.5|AnyCPU'">
-    <OutputPath>bin\Release 4.5\</OutputPath>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <OutputPath>bin\Release45\</OutputPath>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release 4.5.1|AnyCPU'">
-    <OutputPath>bin\Release 4.5.1\</OutputPath>
+    <TargetFrameworkVersion>v4.5.1</TargetFrameworkVersion>
+    <OutputPath>bin\Release\</OutputPath>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />

--- a/SpecEasy.Specs/ExternalSpec/MagicNumberAdderSpec.cs
+++ b/SpecEasy.Specs/ExternalSpec/MagicNumberAdderSpec.cs
@@ -1,6 +1,6 @@
-﻿using SpecEasy.ExternalLib;
-using Rhino.Mocks;
+﻿using Rhino.Mocks;
 using Should;
+using SpecEasy.ExternalLib;
 
 namespace SpecEasy.Specs.ExternalSpec
 {

--- a/SpecEasy.Specs/TinyIoC/TinyIoCSinglePrivateCtorSpec.cs
+++ b/SpecEasy.Specs/TinyIoC/TinyIoCSinglePrivateCtorSpec.cs
@@ -3,6 +3,7 @@ using Should;
 
 namespace SpecEasy.Specs.TinyIoC
 {
+#if DEBUG
     internal class TinyIoCSinglePrivateCtorSpec : Spec<SinglePrivateCtor>
     {
         public void ConstructorSelection()
@@ -13,4 +14,6 @@ namespace SpecEasy.Specs.TinyIoC
                 Then("an exception should be thrown because we will not use private ctors to build the SUT instance", () => AssertWasThrown<Exception>(ex => ex.GetType().FullName.ShouldStartWith("TinyIoC.TinyIoCResolutionException"))));
         }
     }
+
+#endif
 }

--- a/SpecEasy.Specs/TinyIoC/TinyIoCSinglePrivateCtorSpec.cs
+++ b/SpecEasy.Specs/TinyIoC/TinyIoCSinglePrivateCtorSpec.cs
@@ -3,7 +3,6 @@ using Should;
 
 namespace SpecEasy.Specs.TinyIoC
 {
-#if DEBUG
     internal class TinyIoCSinglePrivateCtorSpec : Spec<SinglePrivateCtor>
     {
         public void ConstructorSelection()
@@ -14,6 +13,4 @@ namespace SpecEasy.Specs.TinyIoC
                 Then("an exception should be thrown because we will not use private ctors to build the SUT instance", () => AssertWasThrown<Exception>(ex => ex.GetType().FullName.ShouldStartWith("TinyIoC.TinyIoCResolutionException"))));
         }
     }
-
-#endif
 }

--- a/SpecEasy/Properties/AssemblyInfo.cs
+++ b/SpecEasy/Properties/AssemblyInfo.cs
@@ -10,7 +10,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("TrackAbout, Inc.")]
 [assembly: AssemblyProduct("SpecEasy")]
-[assembly: AssemblyCopyright("Copyright ©2013 TrackAbout, Inc.")]
+[assembly: AssemblyCopyright("Copyright ©2016 SpecEasy")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 

--- a/SpecEasy/SpecEasy.csproj
+++ b/SpecEasy/SpecEasy.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" ToolsVersion="12.0">
   <PropertyGroup>
-    <Configuration Condition=" '$(Configuration)' == '' ">Release 4.5.1</Configuration>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug 4.5.1</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
     <ProductVersion>9.0.30729</ProductVersion>
     <SchemaVersion>2.0</SchemaVersion>

--- a/SpecEasy/SpecEasy.nuspec
+++ b/SpecEasy/SpecEasy.nuspec
@@ -6,20 +6,20 @@
     <title>$title$</title>
     <authors>$author$</authors>
     <owners>$author$</owners>
-    <licenseUrl>https://github.com/trackabout/speceasy/blob/master/LICENSE</licenseUrl>
-    <projectUrl>https://github.com/trackabout/speceasy</projectUrl>
-    <iconUrl>https://raw.github.com/trackabout/speceasy/master/speceasy_logo_sq_128.png</iconUrl>
+    <licenseUrl>https://github.com/speceasy/speceasy/blob/master/LICENSE</licenseUrl>
+    <projectUrl>https://github.com/speceasy/speceasy</projectUrl>
+    <iconUrl>https://raw.github.com/speceasy/speceasy/master/speceasy_logo_sq_128.png</iconUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>$description$</description>
     <releaseNotes>
 Version 2.1.0 of SpecEasy includes:
   - Prevent exceptions in the method under test from being ignored when there is also an assertion failure. See https://github.com/trackabout/speceasy/pull/24.
   - Added the ability to detect and use non-public constructors when constructing the SUT.
-  - Enable the testing of abstract classes. 
+  - Enable the testing of abstract classes.
   - Support for .NET 4.5 in addition to the existing .NET 4.5.1 support.
   - Several other minor fixes.
     </releaseNotes>
-    <copyright>Copyright 2015</copyright>
+    <copyright>Copyright 2016</copyright>
     <tags>bdd tdd unit test testing fluent</tags>
   </metadata>
   <files>

--- a/SpecEasy/SpecEasy.nuspec
+++ b/SpecEasy/SpecEasy.nuspec
@@ -13,7 +13,9 @@
     <description>$description$</description>
     <releaseNotes>
 Version 2.1.0 of SpecEasy includes:
-  - A fix that prevents exceptions in the method under test from being ignored when there is also an assertion failure. See https://github.com/trackabout/speceasy/pull/24.
+  - Prevent exceptions in the method under test from being ignored when there is also an assertion failure. See https://github.com/trackabout/speceasy/pull/24.
+  - Added the ability to detect and use non-public constructors when constructing the SUT.
+  - Enable the testing of abstract classes. 
   - Support for .NET 4.5 in addition to the existing .NET 4.5.1 support.
   - Several other minor fixes.
     </releaseNotes>

--- a/SpecEasy/SpecEasy.nuspec
+++ b/SpecEasy/SpecEasy.nuspec
@@ -17,7 +17,9 @@ Version 2.1.0 of SpecEasy includes:
   - Added the ability to detect and use non-public constructors when constructing the SUT.
   - Enable the testing of abstract classes.
   - Support for .NET 4.5 in addition to the existing .NET 4.5.1 support.
-  - Several other minor fixes.
+  - Include spec method names as prefix for test case description.
+  - Added `And` and `But` spec context methods. These methods set up context identically to the original `Given` methods but are provided as a way to improve readability.
+  - Several other minor fixes and improvements.
     </releaseNotes>
     <copyright>Copyright 2016</copyright>
     <tags>bdd tdd unit test testing fluent</tags>

--- a/SpecEasy/SpecEasy.nuspec
+++ b/SpecEasy/SpecEasy.nuspec
@@ -24,9 +24,4 @@ Version 2.1.0 of SpecEasy includes:
     <copyright>Copyright 2016</copyright>
     <tags>bdd tdd unit test testing fluent</tags>
   </metadata>
-  <files>
-    <!-- Do not need to include .NET 4.5.1 version here because nuget automatically adds the output of
-         either the default build configuration or the configuration specified when running the pack command. -->
-    <file src="..\SpecEasy\bin\Release45\$id$.dll" target="lib\net45\" />
-  </files>
 </package>

--- a/build/build.nuget.bat
+++ b/build/build.nuget.bat
@@ -1,4 +1,5 @@
-SET MSBUILD="C:\Program Files (x86)\MSBuild\14.0\Bin\MSBuild.exe"
+REM Change path to msbuild if not in system PATH.
+SET MSBUILD="MSBuild.exe"
 
 %MSBUILD% ..\SpecEasy.sln /target:Rebuild /p:Configuration="Release 4.5"
 %MSBUILD% ..\SpecEasy.sln /target:Rebuild /p:Configuration="Release 4.5.1"

--- a/build/build.nuget.bat
+++ b/build/build.nuget.bat
@@ -1,4 +1,4 @@
-SET MSBUILD=C:\Windows\Microsoft.NET\Framework\v4.0.30319\msbuild.exe
+SET MSBUILD="C:\Program Files (x86)\MSBuild\14.0\Bin\MSBuild.exe"
 
 %MSBUILD% ..\SpecEasy.sln /target:Rebuild /p:Configuration="Release 4.5"
 %MSBUILD% ..\SpecEasy.sln /target:Rebuild /p:Configuration="Release 4.5.1"

--- a/build/readme.md
+++ b/build/readme.md
@@ -14,5 +14,7 @@
   1. Run `build.nuget.bat`. This will create the NuGet package - `SpecEasy.x.x.x.x.nupkg`.
   1. Push to nuget.org.
 
-     ```..\.nuget\NuGet.exe push SpecEasy.x.x.x.x.nupkg -s http://www.nuget.org/packages/SpecEasy [api key]```
+     ```
+     ..\.nuget\NuGet.exe push SpecEasy.x.x.x.x.nupkg -s http://www.nuget.org/packages/SpecEasy [api key]
+     ```
 

--- a/build/readme.md
+++ b/build/readme.md
@@ -1,0 +1,18 @@
+# Deploy a NuGet Release
+
+1. Update AssemblyInfo.cs file attributes:
+  - `AssemblyCopyright`
+  - `AssemblyVersion`
+  - other attributes, if necessary.
+1. Update the `SpecEasy.nuspec` file:
+  - `releaseNotes`
+  - `copyright`
+  - other elements as required.
+1. Update `build/build.nuget.bat` with new builds and/or version numbers, if necessary.
+1. Build NuGet package and deploy:
+  1. Open a command prompt in the `build` folder.
+  1. Run `build.nuget.bat`. This will create the NuGet package - `SpecEasy.x.x.x.x.nupkg`.
+  1. Push to nuget.org.
+
+    ..\.nuget\NuGet.exe push SpecEasy.x.x.x.x.nupkg -s http://www.nuget.org/packages/SpecEasy [api key]
+

--- a/build/readme.md
+++ b/build/readme.md
@@ -14,5 +14,5 @@
   1. Run `build.nuget.bat`. This will create the NuGet package - `SpecEasy.x.x.x.x.nupkg`.
   1. Push to nuget.org.
 
-    ..\.nuget\NuGet.exe push SpecEasy.x.x.x.x.nupkg -s http://www.nuget.org/packages/SpecEasy [api key]
+     ```..\.nuget\NuGet.exe push SpecEasy.x.x.x.x.nupkg -s http://www.nuget.org/packages/SpecEasy [api key]```
 


### PR DESCRIPTION
- Updated release notes in the Nuget configuration to include changes that were made since we started prepping v2.1.
- TinyIoCSinglePrivateCtorSpec compile was failing in the release build configuration because it referenced internal class TinyIoCResolutionException in the SpecEasy project, which is only visible in debug build. The TinyIoCSinglePrivateCtorSpec is now only included in the debug build.
- Specs project build was failing in the .NET 4.5 build configuration because the ExternalLib project was targeting .NET 4.5.1.
- update Nuget build to use MSBuild v14.0.

As soon as this PR is approved, I will push the new release to Nuget.
