### PR TITLE
Re-enable ability to construct SUT with internal CTOR

### DIFF
--- a/SpecEasy/TinyIoC.cs
+++ b/SpecEasy/TinyIoC.cs
@@ -3759,7 +3759,7 @@ namespace TinyIoC
 #endif
             if (constructor == null)
             {
-                constructor = GetConstructor(typeToConstruct, parameters, options, BindingFlags.Instance | BindingFlags.Public);
+                constructor = GetConstructor(typeToConstruct, parameters, options, BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic);
             }
 
             if (constructor == null)


### PR DESCRIPTION
@appakz and @rockhymas: [PR 31](https://github.com/trackabout/speceasy/pull/31) Made a change that disabled the ability to use internal ctors when building the SUT. I was made aware of this because the `MagicNumberAdderSpec` tests were failing. I believe the problem was that we changed [`TinyIoC.GetTypeConstructors(...)`](https://github.com/trackabout/speceasy/blob/master/SpecEasy/TinyIoC.cs#L3708) to using `BindingFlags` to get the constructors instead of calling `type.GetTypeInfo().DeclaredConstructors`. The `BindingFlags` passed in did not include `BindingFlags.NonPublic`.
