### PR TITLE
Better error reporting around duplicate Given and Then descriptions

### DIFF
--- a/SpecEasy.Specs/DuplicateDescriptions/DuplicateDescriptionsTests.cs
+++ b/SpecEasy.Specs/DuplicateDescriptions/DuplicateDescriptionsTests.cs
@@ -1,0 +1,19 @@
+﻿using System.Linq;
+using NUnit.Framework;
+using SpecEasy.Specs.DuplicateDescriptions.SupportingExamples;
+
+namespace SpecEasy.Specs.DuplicateDescriptions
+{
+    [TestFixture]
+    public class DuplicateDescriptionsTests
+    {
+        [Test]
+        public void ThrowSpecificExceptionForDuplicateGivenDescriptions()
+        {
+            var result = SpecRunner.Run<DuplicateDescriptionsSpec>();
+            Assert.Greater(result.FailedTests().Count(), 0, "Test cases should have failed");
+            Assert.IsTrue(result.FailedTests().All(ft => ft.Message.StartsWith(typeof(DuplicateDescriptionException).FullName)), "Every failure should have reported an exception specific to a description having been repeated");
+            Assert.IsTrue(result.FailedTests().All(ft => ft.StackTrace.Contains(typeof(DuplicateDescriptionsSpec).FullName)), "Every failure's stack trace should include a line number from the spec that failed");
+        }
+    }
+}

--- a/SpecEasy.Specs/DuplicateDescriptions/SupportingExamples/DuplicateDescriptionsSpec.cs
+++ b/SpecEasy.Specs/DuplicateDescriptions/SupportingExamples/DuplicateDescriptionsSpec.cs
@@ -1,0 +1,55 @@
+using NUnit.Framework;
+
+namespace SpecEasy.Specs.DuplicateDescriptions.SupportingExamples
+{
+    [SupportingExample]
+    internal class DuplicateDescriptionsSpec : Spec
+    {
+        private const string DuplicatedGivenDescription = "my given description";
+        private const string DuplicatedThenDescription  = "my then description";
+
+        public void DuplicateGivenDescriptions()
+        {
+            When("running a spec", () => {});
+
+            Given(DuplicatedGivenDescription).Verify(() =>
+                Then("assert 1", () => Assert.Pass()));
+
+            Given(DuplicatedGivenDescription).Verify(() =>
+                Then("assert 2", () => Assert.Pass()));
+        }
+
+        public void DuplicateNestedGivenDescriptions()
+        {
+            When("running a spec", () => {});
+
+            Given("outer given").Verify(() =>
+            {
+                Given(DuplicatedGivenDescription).Verify(() =>
+                    Then("assert 1", () => Assert.Pass()));
+
+                Given(DuplicatedGivenDescription).Verify(() =>
+                    Then("assert 2", () => Assert.Pass()));
+            });
+        }
+
+        public void DuplicateThenDescriptions()
+        {
+            When("running a spec", () => {});
+
+            Then(DuplicatedThenDescription, () => Assert.Pass());
+            Then(DuplicatedThenDescription, () => Assert.Pass());
+        }
+
+        public void DuplicateNestedThenDescriptions()
+        {
+            When("running a spec", () => { });
+
+            Given("outer given").Verify(() =>
+            {
+                Then(DuplicatedThenDescription, () => Assert.Pass());
+                Then(DuplicatedThenDescription, () => Assert.Pass());
+            });
+        }
+    }
+}

--- a/SpecEasy.Specs/SpecEasy.Specs.csproj
+++ b/SpecEasy.Specs/SpecEasy.Specs.csproj
@@ -117,12 +117,14 @@
     <Compile Include="BeforeEachAndAfterEachExampleSpecs\GetSetInBeforeEachExampleSpec.cs" />
     <Compile Include="BeforeEachAndAfterEachExampleSpecs\SutInBeforeEachExampleSpec.cs" />
     <Compile Include="DatabaseIntegration\DatabaseIntegrationSetup.cs" />
+    <Compile Include="DuplicateDescriptions\SupportingExamples\DuplicateDescriptionsSpec.cs" />
     <Compile Include="ExceptionAssertions\ExceptionAssertionsSpec.cs" />
     <Compile Include="ExceptionReporting\ExceptionReporting.cs" />
     <Compile Include="ExceptionReporting\NUnitBrokenClassTests.cs" />
     <Compile Include="ExceptionReporting\TestResultExtensions.cs" />
     <Compile Include="FizzBuzz\FizzBuzzSpecs.cs" />
     <Compile Include="GenericSpec\AutoMockSpec.cs" />
+    <Compile Include="DuplicateDescriptions\DuplicateDescriptionsTests.cs" />
     <Compile Include="GenericSpec\PartialMockSpec.cs" />
     <Compile Include="GenericSpec\PartialMockWithConstructorParamsSpec.cs" />
     <Compile Include="GivenCount\GivenCountSpecs.cs" />

--- a/SpecEasy/DuplicateDescriptionException.cs
+++ b/SpecEasy/DuplicateDescriptionException.cs
@@ -1,0 +1,23 @@
+using System;
+
+namespace SpecEasy
+{
+    public class DuplicateDescriptionException : InvalidOperationException
+    {
+        private readonly string stackTrace;
+
+        internal DuplicateDescriptionException(string typeOfDuplicate, string description, string stackTrace)
+            : base(string.Format("Failed to generate test cases; {0} description '{1}' has already been used", typeOfDuplicate, description))
+        {
+            this.stackTrace = stackTrace;
+        }
+
+        public override string StackTrace
+        {
+            get
+            {
+                return stackTrace;
+            }
+        }
+    }
+}

--- a/SpecEasy/SpecEasy.csproj
+++ b/SpecEasy/SpecEasy.csproj
@@ -96,6 +96,7 @@
   <ItemGroup>
     <Compile Include="Action.cs" />
     <Compile Include="Context.cs" />
+    <Compile Include="DuplicateDescriptionException.cs" />
     <Compile Include="TinyIoC.cs" />
     <Compile Include="VerifyContext.cs" />
     <Compile Include="Spec.cs" />


### PR DESCRIPTION
@rockhymas @appakz @ronrat @mmertsock Please review.

I know I have been burned by this in the past where my `Spec` won't run because I've duplicated a `Given` description.

This change a) surfaces that in a (hopefully) clearer way by failing the spec, and b) includes a stack trace pointing to where the offending `Given` was defined.

Note: https://github.com/trackabout/speceasy/commit/fb32a2fbc603cc3ab657de91c2e6032e952a99ec is the main change here, but builds on the changes added in https://github.com/trackabout/speceasy/commit/699aabfffd55ead0bb17789dd2ac401e5151d848 / #38. If needed I can rewrite this independently.
