### PR TITLE
Allow for more descriptive contexts with Given/And/But methods

### DIFF
--- a/SpecEasy.Specs/Async/AsyncSpec.cs
+++ b/SpecEasy.Specs/Async/AsyncSpec.cs
@@ -9,7 +9,7 @@ namespace SpecEasy.Specs.Async
     {
         private const string Name = "placeholder";
         private const string Value = "The quick brown fox jumped over the lazy dog.";
-     
+
         public void ReturnOne()
         {
             string result = string.Empty;

--- a/SpecEasy.Specs/SpecEasy.Specs.csproj
+++ b/SpecEasy.Specs/SpecEasy.Specs.csproj
@@ -131,9 +131,11 @@
     <Compile Include="GivenCount\GivenCountSpecs.cs" />
     <Compile Include="ExternalSpec\MagicNumberAdderSpec.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="SpecNames\SupportingExamples\SpecNamingSpec.cs" />
     <Compile Include="SpecRunner.cs" />
     <Compile Include="SupportingExampleAttribute.cs" />
     <Compile Include="TestResultExtensions.cs" />
+    <Compile Include="SpecNames\SpecNamingTests.cs" />
     <Compile Include="TinyIoC\PublicAndInternalCtors.cs" />
     <Compile Include="TinyIoC\PublicAndPrivateCtors.cs" />
     <Compile Include="TinyIoC\SinglePrivateCtor.cs" />

--- a/SpecEasy.Specs/SpecNames/SpecNamingTests.cs
+++ b/SpecEasy.Specs/SpecNames/SpecNamingTests.cs
@@ -1,0 +1,18 @@
+﻿using System.Linq;
+using NUnit.Framework;
+using SpecEasy.Specs.SpecNames.SupportingExamples;
+
+namespace SpecEasy.Specs.SpecNames
+{
+    [TestFixture]
+    public class SpecNamingTests
+    {
+        [Test]
+        public void RunSpecsAndCheckNames()
+        {
+            var result = SpecRunner.Run<SpecNamingSpec>();
+            var allTests = result.AllTests();
+            Assert.IsTrue(allTests.All(t => t.Name == SpecNamingSpec.ExpectedSpecName));
+        }
+    }
+}

--- a/SpecEasy.Specs/SpecNames/SupportingExamples/SpecNamingSpec.cs
+++ b/SpecEasy.Specs/SpecNames/SupportingExamples/SpecNamingSpec.cs
@@ -1,0 +1,23 @@
+﻿namespace SpecEasy.Specs.SpecNames.SupportingExamples
+{
+    [SupportingExample]
+    internal class SpecNamingSpec : Spec
+    {
+        public static string ExpectedSpecName = "given a context\r\n  and a sub context\r\n  and another sub context\r\n  but yet another sub context\r\nwhen running the test\r\nthen the test passes\r\n";
+
+        public void RunSpec()
+        {
+            When("running the test", () => { });
+
+            Given("a context", () => { }).Verify(() =>
+            Given("a sub context", () => { }).Verify(() =>
+            And("another sub context", () => { }).Verify(() =>
+            But("yet another sub context", async () => { }).Verify(() =>
+                Then("the test passes", () => AnExampleTestThatPasses())))));
+        }
+
+        private void AnExampleTestThatPasses()
+        {
+        }
+    }
+}

--- a/SpecEasy.Specs/TestResultExtensions.cs
+++ b/SpecEasy.Specs/TestResultExtensions.cs
@@ -15,5 +15,16 @@ namespace SpecEasy.Specs
                 failedTests.AddRange(FailedTests((TestResult)childResult));
             return failedTests;
         }
+
+        public static IEnumerable<TestResult> AllTests(this TestResult testResult)
+        {
+            if (testResult.Results == null || testResult.Results.Count == 0)
+                return new[] { testResult };
+
+            var tests = new List<TestResult>();
+            foreach (var childResult in testResult.Results)
+                tests.AddRange(AllTests((TestResult)childResult));
+            return tests;
+        }
     }
 }

--- a/SpecEasy/Context.cs
+++ b/SpecEasy/Context.cs
@@ -1,5 +1,6 @@
 using System.Threading.Tasks;
 using System;
+using System.Globalization;
 
 namespace SpecEasy
 {
@@ -10,6 +11,21 @@ namespace SpecEasy
 
     internal class Context : IContext
     {
+        public const string GivenConjunction = "given ";
+        public const string AndConjunction = "  and ";
+        public const string ButConjunction = "  but ";
+
+        private const string UnnamedContextPrefix = "SPECEASY";
+        private const string DefaultFirstConjunction = GivenConjunction;
+        private const string DefaultJoiningConjunction = AndConjunction;
+
+        private static int specContextId;
+        private static string CreateUnnamedContextName()
+        {
+            return UnnamedContextPrefix + (specContextId++).ToString(CultureInfo.InvariantCulture);
+        }
+
+        private readonly string conjunction;
         private readonly Func<Task> setupAction = async delegate { };
         private Action enterAction = delegate { };
 
@@ -17,14 +33,15 @@ namespace SpecEasy
         {
         }
 
-        public Context(Func<Task> setup)
-        {
-            setupAction = setup;            
-        }
-
-        public Context(Func<Task> setup, Action addSpecs)
+        public Context(Func<Task> setup, string description = null, string conjunction = null)
         {
             setupAction = setup;
+            Description = description ?? CreateUnnamedContextName();
+            this.conjunction = conjunction;
+        }
+
+        public Context(Func<Task> setup, Action addSpecs, string description = null, string conjunction = null) : this(setup, description, conjunction)
+        {
             enterAction = addSpecs;
         }
 
@@ -33,7 +50,7 @@ namespace SpecEasy
             var cachedEnterAction = enterAction;
             enterAction = () => { cachedEnterAction(); addSpecs(); };
         }
-        
+
         public void EnterContext()
         {
             enterAction();
@@ -42,6 +59,25 @@ namespace SpecEasy
         public async Task SetupContext()
         {
             await setupAction().ConfigureAwait(false);
+        }
+
+        public string Description
+        {
+            get;
+            private set;
+        }
+
+        public bool IsNamedContext
+        {
+            get
+            {
+                return !Description.StartsWith(UnnamedContextPrefix);
+            }
+        }
+
+        public string Conjunction(bool first)
+        {
+            return conjunction ?? (first ? DefaultFirstConjunction : DefaultJoiningConjunction);
         }
     }
 }


### PR DESCRIPTION
This change now allows you to write specs that are more descriptive. For
examples, see the readme.

This also involves some extraction of functionality to the Context class. I think we'll want to continue doing that going forward, as well as factoring out spec naming into a separate class, but I haven't gone too wild at this stage.

@ronrat @appakz @dbertram @jsternal 
