### PR TITLE
Always initialize generic spec mocking container

### DIFF
--- a/SpecEasy.Specs/BeforeEachAndAfterEachExampleSpecs/AfterEachExampleGetsCalledSpec.cs
+++ b/SpecEasy.Specs/BeforeEachAndAfterEachExampleSpecs/AfterEachExampleGetsCalledSpec.cs
@@ -32,7 +32,6 @@ namespace SpecEasy.Specs.BeforeEachAndAfterEachExampleSpecs
 
         protected override void AfterEachExample()
         {
-            base.AfterEachExample();
             timesSet = 0; 
         }
     }

--- a/SpecEasy.Specs/BeforeEachAndAfterEachExampleSpecs/AfterEachExampleGetsCalledSpec.cs
+++ b/SpecEasy.Specs/BeforeEachAndAfterEachExampleSpecs/AfterEachExampleGetsCalledSpec.cs
@@ -32,7 +32,7 @@ namespace SpecEasy.Specs.BeforeEachAndAfterEachExampleSpecs
 
         protected override void AfterEachExample()
         {
-            timesSet = 0; 
+            timesSet = 0;
         }
     }
 }

--- a/SpecEasy.Specs/BeforeEachAndAfterEachExampleSpecs/BeforeEachExampleCalledCorrectNumberOfTimesSpec.cs
+++ b/SpecEasy.Specs/BeforeEachAndAfterEachExampleSpecs/BeforeEachExampleCalledCorrectNumberOfTimesSpec.cs
@@ -19,7 +19,7 @@ namespace SpecEasy.Specs.BeforeEachAndAfterEachExampleSpecs
                 Then("it should should call BeforeEachExample a fourth time", () => timesCalled.ShouldEqual(verifyCall++));
                 Then("it should should call BeforeEachExample a fifth time", () => timesCalled.ShouldEqual(verifyCall++));
                 Then("it should should call BeforeEachExample a sixth time", () => timesCalled.ShouldEqual(verifyCall++));
-                Given("there is a second level of given methods", () => timesCalled.ShouldEqual(verifyCall)).Verify(() => 
+                Given("there is a second level of given methods", () => timesCalled.ShouldEqual(verifyCall)).Verify(() =>
                     Then("it should call BeforeEachExample a seventh time.", () => timesCalled.ShouldEqual(verifyCall++)));
             });
         }
@@ -28,8 +28,8 @@ namespace SpecEasy.Specs.BeforeEachAndAfterEachExampleSpecs
         {
             When("running a test that overrides BeforeEachExample", () => timesCalled.ShouldEqual(verifyCall));
 
-            Given("there is a first level of given methods", () => timesCalled.ShouldEqual(verifyCall)).Verify(() => 
-                Given("there is a second level of given methods", () => timesCalled.ShouldEqual(verifyCall)).Verify(() => 
+            Given("there is a first level of given methods", () => timesCalled.ShouldEqual(verifyCall)).Verify(() =>
+                Given("there is a second level of given methods", () => timesCalled.ShouldEqual(verifyCall)).Verify(() =>
                     Then("it should call BeforeEachExample one time.", () => timesCalled.ShouldEqual(verifyCall++))));
         }
 
@@ -37,6 +37,5 @@ namespace SpecEasy.Specs.BeforeEachAndAfterEachExampleSpecs
         {
             timesCalled++;
         }
-         
     }
 }

--- a/SpecEasy.Specs/BeforeEachAndAfterEachExampleSpecs/BeforeEachExampleCalledCorrectNumberOfTimesSpec.cs
+++ b/SpecEasy.Specs/BeforeEachAndAfterEachExampleSpecs/BeforeEachExampleCalledCorrectNumberOfTimesSpec.cs
@@ -35,7 +35,6 @@ namespace SpecEasy.Specs.BeforeEachAndAfterEachExampleSpecs
 
         protected override void BeforeEachExample()
         {
-            base.BeforeEachExample();
             timesCalled++;
         }
          

--- a/SpecEasy.Specs/BeforeEachAndAfterEachExampleSpecs/BeforeEachExampleGetsCalledSpec.cs
+++ b/SpecEasy.Specs/BeforeEachAndAfterEachExampleSpecs/BeforeEachExampleGetsCalledSpec.cs
@@ -12,7 +12,7 @@ namespace SpecEasy.Specs.BeforeEachAndAfterEachExampleSpecs
 
             Then("it should run BeforeEachExample", () => testValue.ShouldEqual(50));
 
-            Given("a given changes the value set in BeforeEachExample", () => testValue = 75).Verify(() => 
+            Given("a given changes the value set in BeforeEachExample", () => testValue = 75).Verify(() =>
                 Then("it should not have the value from BeforeEachExample", () => testValue.ShouldEqual(75)));
         }
 

--- a/SpecEasy.Specs/BeforeEachAndAfterEachExampleSpecs/BeforeEachExampleGetsCalledSpec.cs
+++ b/SpecEasy.Specs/BeforeEachAndAfterEachExampleSpecs/BeforeEachExampleGetsCalledSpec.cs
@@ -18,7 +18,6 @@ namespace SpecEasy.Specs.BeforeEachAndAfterEachExampleSpecs
 
         protected override void BeforeEachExample()
         {
-            base.BeforeEachExample();
             testValue = 50;
         }
     }

--- a/SpecEasy.Specs/BeforeEachAndAfterEachExampleSpecs/GetSetInBeforeEachExampleSpec.cs
+++ b/SpecEasy.Specs/BeforeEachAndAfterEachExampleSpecs/GetSetInBeforeEachExampleSpec.cs
@@ -7,7 +7,6 @@ namespace SpecEasy.Specs.BeforeEachAndAfterEachExampleSpecs
     {
         protected override void BeforeEachExample()
         {
-            base.BeforeEachExample();
             Get<IDependency>().Stub(dep => dep.GetValue()).Return(123);
             Set<IAnotherDependency>(new AnotherDependency(789));
         }

--- a/SpecEasy.Specs/BeforeEachAndAfterEachExampleSpecs/GetSetInBeforeEachExampleSpec.cs
+++ b/SpecEasy.Specs/BeforeEachAndAfterEachExampleSpecs/GetSetInBeforeEachExampleSpec.cs
@@ -16,7 +16,7 @@ namespace SpecEasy.Specs.BeforeEachAndAfterEachExampleSpecs
             var result = 0;
 
             When("using a dependency", () => result = SUT.UseDependency());
-            
+
             Given("dependencies were set up in BeforeEachExample").Verify(() =>
                 Then("it should get a value from the first dependency that was set up", () => result.ShouldEqual(123)).
                 Then("it should get a value from the second dependency that was set up", () => SUT.UseAnotherDependency().ShouldEqual(789)));

--- a/SpecEasy.Specs/BeforeEachAndAfterEachExampleSpecs/SutInBeforeEachExampleSpec.cs
+++ b/SpecEasy.Specs/BeforeEachAndAfterEachExampleSpecs/SutInBeforeEachExampleSpec.cs
@@ -6,7 +6,6 @@ namespace SpecEasy.Specs.BeforeEachAndAfterEachExampleSpecs
     {
         protected override void BeforeEachExample()
         {
-            base.BeforeEachExample();
             SUT = new SutWithValueTypeDependency(123);
         }
 

--- a/SpecEasy.Specs/DatabaseIntegration/DatabaseIntegrationSpec.cs
+++ b/SpecEasy.Specs/DatabaseIntegration/DatabaseIntegrationSpec.cs
@@ -14,7 +14,6 @@ namespace SpecEasy.Specs.DatabaseIntegration
 
         protected override void BeforeEachExample()
         {
-            base.BeforeEachExample();
 			dbConnection = new SqlCeConnection(DatabaseIntegrationSetup.TestDbConnectionString);
             dbConnection.Open();
             transaction = dbConnection.BeginTransaction();
@@ -22,7 +21,6 @@ namespace SpecEasy.Specs.DatabaseIntegration
 
         protected override void AfterEachExample()
         {
-            base.AfterEachExample();
             transaction.Rollback();
             transaction.Dispose();
             dbConnection.Close();

--- a/SpecEasy.Specs/DatabaseIntegration/DatabaseIntegrationSpec.cs
+++ b/SpecEasy.Specs/DatabaseIntegration/DatabaseIntegrationSpec.cs
@@ -33,7 +33,7 @@ namespace SpecEasy.Specs.DatabaseIntegration
 
 		    const string firstPostBody = "this is the body of the first post.";
 		    const string secondPostBody = "body of the second post.";
-            
+
             When("querying a database within a spec", () => queryResult = GetPosts());
 
             Given("a post is created in a test context.", () => CreatePost(firstPostBody)).Verify(() =>
@@ -48,11 +48,11 @@ namespace SpecEasy.Specs.DatabaseIntegration
 		private IList<dynamic> GetPosts()
 		{
 		    return dbConnection.Query("select Id, CreateDate, Author, Body from Posts", transaction: transaction).ToList();
-		} 
+		}
 
 		private void CreatePost(string body)
 		{
-		    dbConnection.Execute("insert Posts (CreateDate, Author, Body) values (@CreateDate, @Author, @Body)", new 
+		    dbConnection.Execute("insert Posts (CreateDate, Author, Body) values (@CreateDate, @Author, @Body)", new
 		        {
 		            CreateDate = DateTime.UtcNow,
 		            Author = "Spec Easy",

--- a/SpecEasy.Specs/TinyIoC/TinyIoCSinglePrivateCtorSpec.cs
+++ b/SpecEasy.Specs/TinyIoC/TinyIoCSinglePrivateCtorSpec.cs
@@ -1,4 +1,5 @@
-using TinyIoC;
+using System;
+using Should;
 
 namespace SpecEasy.Specs.TinyIoC
 {
@@ -9,7 +10,7 @@ namespace SpecEasy.Specs.TinyIoC
             When("constructing the SUT instance", () => EnsureSUT());
 
             Given("the type being constructed has a single private constructor").Verify(() =>
-                Then("an exception should be thrown because we will not use private ctors to build the SUT instance", () => AssertWasThrown<TinyIoCResolutionException>()));
+                Then("an exception should be thrown because we will not use private ctors to build the SUT instance", () => AssertWasThrown<Exception>(ex => ex.GetType().FullName.ShouldStartWith("TinyIoC.TinyIoCResolutionException"))));
         }
     }
 }

--- a/SpecEasy/GenericSpec.cs
+++ b/SpecEasy/GenericSpec.cs
@@ -84,9 +84,10 @@ namespace SpecEasy
             mock.AssertWasNotCalled(action, methodOptions);
         }
 
-        protected override void BeforeEachExample()
+        internal override void BeforeEachInit()
         {
-            base.BeforeEachExample();
+            base.BeforeEachInit();
+
             MockingContainer = new TinyIoCContainer();
 
             if (typeof (TUnit).IsAbstract)

--- a/SpecEasy/Properties/AssemblyInfo.cs
+++ b/SpecEasy/Properties/AssemblyInfo.cs
@@ -32,7 +32,3 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Revision and Build Numbers
 // by using the '*' as shown below:
 [assembly: AssemblyVersion("2.1.0.0")]
-
-#if DEBUG
-[assembly: InternalsVisibleTo("SpecEasy.Specs")]
-#endif

--- a/SpecEasy/Spec.cs
+++ b/SpecEasy/Spec.cs
@@ -82,7 +82,7 @@ namespace SpecEasy
 
                 Func<Task> executeTest = async () =>
                 {
-                    Before();
+                    BeforeIfNotAlreadyRun();
 
                     try
                     {
@@ -309,10 +309,11 @@ namespace SpecEasy
         }
 
         private bool hasCalledBefore;
-        private void Before()
+        private void BeforeIfNotAlreadyRun()
         {
             if (!hasCalledBefore)
             {
+                BeforeEachInit();
                 BeforeEachExample();
                 hasCalledBefore = true;
             }
@@ -327,14 +328,17 @@ namespace SpecEasy
             }
         }
 
+        internal virtual void BeforeEachInit() { }
+
         protected virtual void BeforeEachExample() { }
+
         protected virtual void AfterEachExample() { }
 
         private async Task InitializeContext(IEnumerable<Context> contextList)
         {
             foreach (var context in contextList)
             {
-                Before();
+                BeforeIfNotAlreadyRun();
                 await context.SetupContext().ConfigureAwait(false);
             }
         }


### PR DESCRIPTION
@ronrat @jsternal @appakz @rockhymas Please review.

There are two somewhat related things in this PR:
1. Stop exposing internals from the SpecEasy assembly to SpecEasy.Specs. While this makes the test about `TinyIoCResolutionException` slightly less elegant/more brittle, there has been some talk about making SpecEasy wrap any TinyIoC exceptions with public SpecEasy-specific exceptions anyway. This change also keeps us more honest in SpecEasy.Specs wrt to only using SpecEasy's public API. However, if folks are opposed I can drop this commit.
2. This second commit makes it impossible for someone subclassing `GenericSpec` to be burned by overriding `BeforeEachExample`, but forgetting to call `base.BeforeEachExample()`. I know I've been burned by this before and rather than improving the error message, I thought we could go this route and avoid it altogether by introducing an `internal virtual` method to handle setting up the mocking container.
