### PR TITLE
Spec method name as description prefix

### DIFF
--- a/SpecEasy.Specs/SpecNames/SupportingExamples/SpecNamingSpec.cs
+++ b/SpecEasy.Specs/SpecNames/SupportingExamples/SpecNamingSpec.cs
@@ -3,9 +3,9 @@
     [SupportingExample]
     internal class SpecNamingSpec : Spec
     {
-        public static string ExpectedSpecName = "given a context\r\n  and a sub context\r\n  and another sub context\r\n  but yet another sub context\r\nwhen running the test\r\nthen the test passes\r\n";
+        public static string ExpectedSpecName = "SpecMethod:\r\ngiven a context\r\n  and a sub context\r\n  and another sub context\r\n  but yet another sub context\r\nwhen running the test\r\nthen the test passes\r\n";
 
-        public void RunSpec()
+        public void SpecMethod()
         {
             When("running the test", () => { });
 

--- a/SpecEasy/Spec.cs
+++ b/SpecEasy/Spec.cs
@@ -28,10 +28,10 @@ namespace SpecEasy
         private IList<TestCaseData> BuildTestCases()
         {
             CreateMethodContexts();
-            return BuildTestCasesForContexts(new List<Context>(), 0);
+            return BuildTestCasesForContexts(new List<Context>());
         }
 
-        private IList<TestCaseData> BuildTestCasesForContexts(IList<Context> parentContexts, int depth)
+        private IList<TestCaseData> BuildTestCasesForContexts(IList<Context> parentContexts)
         {
             var testCases = new List<TestCaseData>();
 
@@ -43,15 +43,12 @@ namespace SpecEasy
                 when = cachedWhen;
 
                 currentContext.EnterContext();
-
-                if (depth > 0)
-                    parentContexts.Add(currentContext);
+                parentContexts.Add(currentContext);
 
                 testCases.AddRange(BuildTestCasesForThens(parentContexts));
-                testCases.AddRange(BuildTestCasesForContexts(parentContexts, depth + 1));
+                testCases.AddRange(BuildTestCasesForContexts(parentContexts));
 
-                if (parentContexts.Any())
-                    parentContexts.Remove(currentContext);
+                parentContexts.Remove(currentContext);
             }
 
             return testCases;
@@ -65,8 +62,10 @@ namespace SpecEasy
 
             var setupText = new StringBuilder();
 
+            setupText.AppendLine(parentContexts.First().Description + ":"); // start with the spec method's name
+
             var first = true;
-            foreach (var context in parentContexts.Where(c => c.IsNamedContext))
+            foreach (var context in parentContexts.Skip(1).Where(c => c.IsNamedContext))
             {
                 setupText.AppendLine(context.Conjunction(first) + context.Description);
                 first = false;


### PR DESCRIPTION
@appakz @rockhymas Please review.

The idea here is to make it easier to find the associated spec method for a given test case in the test runner and to also help group related specs together with a common prefix.

Before this change, I found myself frequently searching the (potentially long) test case descriptions for the `When` text that would tie related specs together.

What do you think?
