### PR TITLE
chore: Mark SpecEasy.ExternalLib as a test project

### DIFF
--- a/SpecEasy.ExternalLib/SpecEasy.ExternalLib.csproj
+++ b/SpecEasy.ExternalLib/SpecEasy.ExternalLib.csproj
@@ -1,7 +1,10 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net461;net462;net47;net471;net472;net48;net481;netstandard2.0;netstandard2.1;net5.0;net6.0;net7.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net6.0;net8.0</TargetFrameworks>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <WarningsAsErrors />
   </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+  </ItemGroup>
 </Project>


### PR DESCRIPTION
this is only used in tests.